### PR TITLE
Update http_transport.ts

### DIFF
--- a/src/transports/http/http_transport.ts
+++ b/src/transports/http/http_transport.ts
@@ -123,7 +123,7 @@ export class HttpTransport implements IRequestTransport, HttpTransportOptions {
                         "Accept-Encoding": "gzip, deflate, br, zstd",
                         "Content-Type": "application/json",
                     },
-                    keepalive: true,
+                    keepalive: typeof window !== "undefined",
                     method: "POST",
                     signal: this.timeout ? AbortSignal.timeout(this.timeout) : undefined,
                 },


### PR DESCRIPTION
if keepalive is set to true in a nodejs environment, the request is not executed. It seems that the keepalive parameter is only available in the browser, maybe better to set it to true only in a browser environment