### PR TITLE
fix: use correct channel name for userEvents subscription

### DIFF
--- a/src/clients/subscription.ts
+++ b/src/clients/subscription.ts
@@ -625,7 +625,7 @@ export class SubscriptionClient<
         listener: (data: WsUserEvent) => void,
     ): Promise<Subscription> {
         const payload = { type: "userEvents", ...params } satisfies WsUserEventsRequest;
-        return this.transport.subscribe<WsUserEvent>("user", payload, (e) => {
+        return this.transport.subscribe<WsUserEvent>(payload.type, payload, (e) => {
             listener(e.detail);
         });
     }


### PR DESCRIPTION
## Description

This PR fixes the channel name used by the `userEvents` subscription method.

## Problem

The `userEvents` method was using a hardcoded `"user"` as the channel name instead of `payload.type` (which is `"userEvents"`). This caused the subscription to fail silently with no events received.

## Solution

Changed line 628 in `src/clients/subscription.ts`:
```diff
- return this.transport.subscribe<WsUserEvent>("user", payload, (e) => {
+ return this.transport.subscribe<WsUserEvent>(payload.type, payload, (e) => {
```

This aligns with the pattern used by other subscription methods like `userFills`.

## Testing

Tested the fix with a real wallet address:
- Before: No events received when subscribing to userEvents
- After: Events received correctly

## Related Issues

Fixes #48

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)