### PR TITLE
fix: check if mids response match requested dex

### DIFF
--- a/src/api/subscription/allMids.ts
+++ b/src/api/subscription/allMids.ts
@@ -87,7 +87,7 @@ export function allMids(
       if (pairs.length === 0) return
       const defaultPair = pairs[0]
       // mids is not for the requested dex
-      if (!defaultPair.startsWith(params.dex)) return
+      if (!defaultPair.toLowerCase().startsWith(params.dex.toLowerCase())) return
     }
     listener(e.detail)
   })


### PR DESCRIPTION
When subscribing to multiple mids with different `dex`, some of the subscriptions start getting irrelevant data from other dexs as the response aren't being filtered.

This PR adds a check such that if dex is specified, listener is only invoked if at least one pair starts with matching dex name.