### PR TITLE
fix: loosen overly strict builder fee validation

### DIFF
--- a/src/api/exchange/_methods/order.ts
+++ b/src/api/exchange/_methods/order.ts
@@ -141,11 +141,11 @@ export const OrderRequest = /* @__PURE__ */ (() => {
                 Address,
                 v.description("Builder address."),
               ),
-              /** Builder fee in 0.1bps (1 = 0.0001%). */
+              /** Builder fee in 0.1bps (1 = 0.0001%). Max 100 for perps (0.1%), 1000 for spot (1%). */
               f: v.pipe(
                 UnsignedInteger,
-                v.maxValue(100),
-                v.description("Builder fee in 0.1bps (1 = 0.0001%)."),
+                v.maxValue(1000),
+                v.description("Builder fee in 0.1bps (1 = 0.0001%). Max 100 for perps (0.1%), 1000 for spot (1%)."),
               ),
             })),
             v.description("Builder fee."),


### PR DESCRIPTION
Current validation only allows for a fee of up to 0.1%, which is correct for perp assets, however spot assets can have a fee of up to 1%.

https://hyperliquid.gitbook.io/hyperliquid-docs/trading/builder-codes#api-for-builders