### PR TITLE
Adds missing builderFee in UserFillSchema type

### DIFF
--- a/src/api/info/_methods/_base/commonSchemas.ts
+++ b/src/api/info/_methods/_base/commonSchemas.ts
@@ -509,7 +509,7 @@ export const UserFillSchema = /* @__PURE__ */ (() => {
       ),
       /** Optional fee charged by the UI builder. */
       builderFee: v.pipe(
-        Decimal,
+        v.optional(Decimal),
         v.description("Optional fee charged by the UI builder."),
       ),
       /** Unique transaction identifier for a partial fill of an order. */

--- a/tests/api/info/userFills.test.ts
+++ b/tests/api/info/userFills.test.ts
@@ -8,6 +8,7 @@ runTest({
   codeTestFn: async (_t, client) => {
     const data = await Promise.all([
       client.userFills({ user: "0x563C175E6f11582f65D6d9E360A618699DEe14a9" }),
+      client.userFills({ user: "0x8172cc20bc3a55dcd07c75dd37ac0c2534de3b84" }),
     ]);
     schemaCoverage(UserFillsResponse, data, {
       ignoreDefinedTypes: ["#/items/intersect/0/properties/twapId"],

--- a/tests/api/info/userFillsByTime.test.ts
+++ b/tests/api/info/userFillsByTime.test.ts
@@ -11,6 +11,10 @@ runTest({
         user: "0x563C175E6f11582f65D6d9E360A618699DEe14a9",
         startTime: Date.now() - 1000 * 60 * 60 * 24 * 365 * 5,
       }),
+      client.userFillsByTime({
+        user: "0x8172cc20bc3a55dcd07c75dd37ac0c2534de3b84",
+        startTime: Date.now() - 1000 * 60 * 60 * 24 * 365 * 5,
+      }),
     ]);
     schemaCoverage(UserFillsByTimeResponse, data, {
       ignoreDefinedTypes: [

--- a/tests/api/info/userTwapSliceFills.test.ts
+++ b/tests/api/info/userTwapSliceFills.test.ts
@@ -12,6 +12,7 @@ runTest({
     schemaCoverage(UserTwapSliceFillsResponse, data, {
       ignoreDefinedTypes: [
         "#/items/properties/fill/properties/twapId",
+        "#/items/properties/fill/properties/builderFee",
       ],
     });
   },

--- a/tests/api/info/userTwapSliceFillsByTime.test.ts
+++ b/tests/api/info/userTwapSliceFillsByTime.test.ts
@@ -15,6 +15,7 @@ runTest({
     schemaCoverage(UserTwapSliceFillsByTimeResponse, data, {
       ignoreDefinedTypes: [
         "#/items/properties/fill/properties/twapId",
+        "#/items/properties/fill/properties/builderFee",
       ],
     });
   },

--- a/tests/api/subscription/userFills.test.ts
+++ b/tests/api/subscription/userFills.test.ts
@@ -13,6 +13,7 @@ runTest({
     schemaCoverage(UserFillsEvent, data, {
       ignoreDefinedTypes: [
         "#/properties/fills/items/intersect/0/properties/twapId",
+        "#/properties/fills/items/intersect/0/properties/builderFee",
       ],
       ignoreUndefinedTypes: [
         "#/properties/isSnapshot",

--- a/tests/api/subscription/userTwapSliceFills.test.ts
+++ b/tests/api/subscription/userTwapSliceFills.test.ts
@@ -12,7 +12,10 @@ runTest({
     }, 10_000);
     schemaCoverage(UserTwapSliceFillsEvent, data, {
       ignoreUndefinedTypes: ["#/properties/isSnapshot"],
-      ignoreDefinedTypes: ["#/properties/twapSliceFills/items/properties/fill/properties/twapId"],
+      ignoreDefinedTypes: [
+        "#/properties/twapSliceFills/items/properties/fill/properties/twapId",
+        "#/properties/twapSliceFills/items/properties/fill/properties/builderFee",
+      ],
     });
   },
 });


### PR DESCRIPTION
When an order is placed from an external UI, the UI builder may have set a builder fee that is in the UserFillSchema response, between fee and tid.