### PR TITLE
feat(symbolConverter): add hip4 recurring outcome support

### DIFF
--- a/src/utils/_symbolConverter.ts
+++ b/src/utils/_symbolConverter.ts
@@ -211,6 +211,8 @@ export class SymbolConverter {
         if (!slug) return;
 
         this._nameToAssetId.set(slug, 100000000 + 10 * outcome.outcome + sideIdx);
+        // Outcome markets are absent from szDecimals metadata; they are all 5
+        this._nameToSzDecimals.set(slug, 5);
       });
     });
   }
@@ -330,6 +332,7 @@ export class SymbolConverter {
    * - For Perpetuals, use the coin name (e.g., "BTC").
    * - For Spots, use the "BASE/QUOTE" format (e.g., "HYPE/USDC").
    * - For Builder Dexs, use the "DEX_NAME:ASSET_NAME" format (e.g., "test:ABC").
+   * - For Outcome Markets, use the slug as in the URL (e.g., "btc-above-61720-yes-jun-08-0600").
    *
    * @example
    * ```ts
@@ -342,6 +345,7 @@ export class SymbolConverter {
    * converter.getSzDecimals("BTC"); // → 5
    * converter.getSzDecimals("HYPE/USDC"); // → 2
    * converter.getSzDecimals("test:ABC"); // → 0
+   * converter.getSzDecimals("btc-above-61720-yes-jun-08-0600"); // → 5
    * ```
    */
   getSzDecimals(name: string): number | undefined {

--- a/src/utils/_symbolConverter.ts
+++ b/src/utils/_symbolConverter.ts
@@ -193,126 +193,107 @@ export class SymbolConverter {
   // ============================================================
 
   private _processOutcomeMarkets(outcomeMetaData: OutcomeMetaResponse): void {
-    this._processBinaryOutcomeAssets(outcomeMetaData);
-    this._processRecurringBucketOutcomeAssets(outcomeMetaData);
-  }
+    // Map each named outcome to its owning question, which holds the price spec and bucket order
+    const questionByOutcome = new Map<number, OutcomeMetaResponse["questions"][number]>();
+    outcomeMetaData.questions.forEach((question) => {
+      question.namedOutcomes.forEach((outcomeId) => questionByOutcome.set(outcomeId, question));
+    });
 
-  /**
-   * Populates binary (`priceBinary`) outcome market slugs.
-   */
-  private _processBinaryOutcomeAssets(outcomeMetaData: OutcomeMetaResponse): void {
+    // Fallback outcomes are not tradable on their own and have no public slug
+    const fallbackOutcomes = new Set(outcomeMetaData.questions.map((question) => question.fallbackOutcome));
+
     outcomeMetaData.outcomes.forEach((outcome) => {
-      if (outcome.name !== "Recurring" || !outcome.description.includes("class:priceBinary")) return;
+      if (fallbackOutcomes.has(outcome.outcome)) return;
+      const question = questionByOutcome.get(outcome.outcome);
 
       outcome.sideSpecs.forEach((sideSpec, sideIdx) => {
-        this._populateIndividualBucketOutcome(
-          outcome.outcome,
-          sideSpec.name,
-          sideIdx,
-          outcome.description,
-          0,
-        );
+        const slug = this._outcomeSlug(outcome, sideSpec.name, question);
+        if (!slug) return;
+
+        this._nameToAssetId.set(slug, 100000000 + 10 * outcome.outcome + sideIdx);
       });
     });
   }
 
   /**
-   * Populates multi-price (`priceBucket`) outcome market slugs.
+   * Builds the URL slug for an outcome side.
+   *
+   * Recurring price markets encode their slug in a `class:price*` description; every other market
+   * derives it from the question, outcome, and side names (e.g. "nba-finals-game-3-san-antonio").
    */
-  private _processRecurringBucketOutcomeAssets(outcomeMetaData: OutcomeMetaResponse): void {
-    outcomeMetaData.questions.forEach((question) => {
-      if (question.name === "Recurring" && question.description.includes("class:priceBucket")) {
-        if (question.namedOutcomes.length !== 3) return;
-
-        question.namedOutcomes.forEach((outcomeId: number, outcomeIndex: number) => {
-          const outcomeObj = outcomeMetaData.outcomes.find((entry) => entry.outcome === outcomeId);
-
-          if (outcomeObj) {
-            outcomeObj.sideSpecs.forEach((sideSpec, sideIdx) => {
-              this._populateIndividualBucketOutcome(
-                outcomeObj.outcome,
-                sideSpec.name,
-                sideIdx,
-                question.description,
-                outcomeIndex,
-              );
-            });
-          }
-        });
-      }
-    });
+  private _outcomeSlug(
+    outcome: OutcomeMetaResponse["outcomes"][number],
+    side: string,
+    question?: OutcomeMetaResponse["questions"][number],
+  ): string | null {
+    if (outcome.description.includes("class:priceBinary")) {
+      return this._recurringPriceSlug(outcome.description, side, 0);
+    }
+    if (question?.description.includes("class:priceBucket")) {
+      return this._recurringPriceSlug(question.description, side, question.namedOutcomes.indexOf(outcome.outcome));
+    }
+    return [question?.name, outcome.name, side]
+      .filter((part) => part !== undefined)
+      .map((part) => this._slugify(part))
+      .join("-");
   }
 
   /**
-   * Maps the slug to the assetId as per the specification.
+   * Builds the slug for a recurring price market from its `class:price*` description.
    *
-   * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/asset-ids
-   */
-  private _populateIndividualBucketOutcome(
-    outcomeId: number,
-    sideSpec: string,
-    sideIdx: number,
-    description: string,
-    outcomeIndex: number,
-  ): void {
-    const slug = this._descriptionToSlug(description, sideSpec, outcomeIndex);
-    if (!slug) return;
-    const encoding = 10 * outcomeId + sideIdx;
-    const assetId = 100000000 + encoding;
-
-    this._nameToAssetId.set(slug, assetId);
-  }
-
-  /**
-   * Generates the appropriate slug for binary and multi-price (bucket) outcome markets.
-   *
-   * @param description Complete description of an outcome.
-   * @param side Side name retrieved from the sideSpecs.
-   * @param outcomeIndex Bucket classification (0 = below, 1 = between, 2 = above).
-   * @return The generated slug.
+   * @param spec Pipe-delimited recurring market spec (e.g. "class:priceBinary|underlying:BTC|expiry:...").
+   * @param side Side name (e.g. "Yes").
+   * @param bucketIndex Price range position for `priceBucket` markets (0 = below, 1 = between, 2 = above).
+   * @return The generated slug, or `null` if the spec is incomplete or of an unknown class.
    *
    * @see https://hyperliquid.gitbook.io/hyperliquid-docs/trading/contract-specifications
    */
-  private _descriptionToSlug(description: string, side: string, outcomeIndex: number): string | null {
-    const parts = description.split("|");
-    const lookup: Record<string, string> = {};
-
-    for (const part of parts) {
-      const [key, value] = part.split(":");
-      lookup[key] = value;
+  private _recurringPriceSlug(spec: string, side: string, bucketIndex: number): string | null {
+    const fields: Record<string, string> = {};
+    for (const part of spec.split("|")) {
+      const [key, ...value] = part.split(":");
+      fields[key] = value.join(":");
     }
 
-    const { class: assetClass, underlying, expiry } = lookup;
-
+    const { class: assetClass, underlying, expiry } = fields;
     if (!assetClass || !underlying || !expiry) return null;
 
+    // Expiry "YYYYMMDD-HHMM" becomes the slug date "mon-dd-HHMM"
     const months = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
-    const monthName = months[parseInt(expiry.slice(4, 6)) - 1];
-    const day = expiry.slice(6, 8);
-    const time = expiry.slice(9, 13);
-    const dateStr = `${monthName}-${day}-${time}`;
+    const date = `${months[Number(expiry.slice(4, 6)) - 1]}-${expiry.slice(6, 8)}-${expiry.slice(9, 13)}`;
 
     if (assetClass === "priceBinary") {
-      const { targetPrice } = lookup;
+      const { targetPrice } = fields;
       if (!targetPrice) return null;
-      return `${underlying}-above-${targetPrice}-${side}-${dateStr}`.toLowerCase();
+      return `${underlying}-above-${targetPrice}-${side}-${date}`.toLowerCase();
     }
 
     if (assetClass === "priceBucket") {
-      const { priceThresholds } = lookup;
-      if (!priceThresholds) return null;
-      const prices = priceThresholds.split(",");
-      if (prices.length !== 2) return null;
+      const prices = fields.priceThresholds?.split(",");
+      if (prices?.length !== 2) return null;
 
-      const bucketStr = outcomeIndex === 0
-        ? `below-${prices[0]}`
-        : outcomeIndex === 1
-        ? `${prices[0]}-to-${prices[1]}`
-        : `above-${prices[1]}`;
+      let range: string;
+      if (bucketIndex === 0) {
+        range = `below-${prices[0]}`;
+      } else if (bucketIndex === 1) {
+        range = `${prices[0]}-to-${prices[1]}`;
+      } else {
+        range = `above-${prices[1]}`;
+      }
 
-      return `${underlying}-price-range-${dateStr}-${bucketStr}-${side}`.toLowerCase();
+      return `${underlying}-price-range-${date}-${range}-${side}`.toLowerCase();
     }
+
     return null;
+  }
+
+  /** Converts a market or side name to a URL slug. */
+  private _slugify(name: string): string {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/[\s-]+/g, "-")
+      .replace(/^-+|-+$/g, "");
   }
 
   // ============================================================

--- a/src/utils/_symbolConverter.ts
+++ b/src/utils/_symbolConverter.ts
@@ -1,6 +1,8 @@
 import {
   meta,
   type MetaResponse,
+  outcomeMeta,
+  type OutcomeMetaResponse,
   perpDexs,
   type PerpDexsResponse,
   spotMeta,
@@ -95,10 +97,11 @@ export class SymbolConverter {
     const config = { transport: this._transport };
     const needDexs = this._dexOption === true || (Array.isArray(this._dexOption) && this._dexOption.length > 0);
 
-    const [perpMetaData, spotMetaData, perpDexsData] = await Promise.all([
+    const [perpMetaData, spotMetaData, perpDexsData, outcomeMetaData] = await Promise.all([
       meta(config),
       spotMeta(config),
       needDexs ? perpDexs(config) : undefined,
+      outcomeMeta(config),
     ]);
 
     if (!perpMetaData?.universe?.length) {
@@ -116,6 +119,7 @@ export class SymbolConverter {
 
     this._processDefaultPerps(perpMetaData);
     this._processSpotAssets(spotMetaData);
+    this._processAllRecurringOutcomeAssets(outcomeMetaData);
 
     // Only process builder dexs if dex support is enabled
     if (perpDexsData) {
@@ -190,6 +194,125 @@ export class SymbolConverter {
     });
   }
 
+  private _processAllRecurringOutcomeAssets(outcomeMetaData: OutcomeMetaResponse): void {
+    this._processBinaryOutcomeAssets(outcomeMetaData);
+    this._processRecurringBucketOutcomeAssets(outcomeMetaData);
+  }
+  /**
+   * Handle the population of binary(priceBinary) outcome market slugs
+   */
+  private _processBinaryOutcomeAssets(outcomeMetaData: OutcomeMetaResponse): void {
+    outcomeMetaData.outcomes.forEach((outcome) => {
+      if (outcome.name !== "Recurring" || !outcome.description.includes("class:priceBinary")) return;
+
+      outcome.sideSpecs.forEach((sideSpec, sideIdx) => {
+        this._populateIndividualBucketOutcome(
+          outcome.outcome,
+          sideSpec.name,
+          sideIdx,
+          outcome.description,
+          0,
+        );
+      });
+    });
+  }
+
+  /**
+   * Handle the population of multi-price(priceBucket) outcome market slugs
+   */
+  private _processRecurringBucketOutcomeAssets(outcomeMetaData: OutcomeMetaResponse): void {
+    outcomeMetaData.questions.forEach((question) => {
+      if (question.name === "Recurring" && question.description.includes("class:priceBucket")) {
+        if (question.namedOutcomes.length !== 3) return;
+
+        question.namedOutcomes.forEach((outcomeId: number, outcomeIndex: number) => {
+          const outcomeObj = outcomeMetaData.outcomes.find((entry) => entry.outcome === outcomeId);
+
+          if (outcomeObj) {
+            outcomeObj.sideSpecs.forEach((sideSpec, sideIdx) => {
+              this._populateIndividualBucketOutcome(
+                outcomeObj.outcome,
+                sideSpec.name,
+                sideIdx,
+                question.description,
+                outcomeIndex,
+              );
+            });
+          }
+        });
+      }
+    });
+  }
+
+  /**
+   * Map the slug to the assetId as per the specification:
+   * {@link https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/asset-ids}
+   */
+  private _populateIndividualBucketOutcome(
+    outcomeId: number,
+    sideSpec: string,
+    sideIdx: number,
+    description: string,
+    outcomeIndex: number,
+  ): void {
+    const slug = this._descriptionToSlug(description, sideSpec, outcomeIndex);
+    if (!slug) return;
+    const encoding = 10 * outcomeId + sideIdx;
+    const assetId = 100000000 + encoding;
+
+    this._nameToAssetId.set(slug, assetId);
+  }
+
+  /**
+   * Generate the appropiate slug for binary and multi-price(bucket) outcome markets
+   * {@link https://hyperliquid.gitbook.io/hyperliquid-docs/trading/contract-specifications}
+   * @param description complete description of an outcome
+   * @param side for the requested slug retrieved from the sideSpecs
+   * @param outcomeIndex for the classification of the bucket: (0 -> below, 1-between, 2-above)
+   * @returns the generated slug
+   */
+  private _descriptionToSlug(description: string, side: string, outcomeIndex: number): string | null {
+    const parts = description.split("|");
+    const lookup: Record<string, string> = {};
+
+    for (const part of parts) {
+      const [key, value] = part.split(":");
+      lookup[key] = value;
+    }
+
+    const { class: assetClass, underlying, expiry } = lookup;
+
+    if (!assetClass || !underlying || !expiry) return null;
+
+    const months = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
+    const monthName = months[parseInt(expiry.slice(4, 6)) - 1];
+    const day = expiry.slice(6, 8);
+    const time = expiry.slice(9, 13);
+    const dateStr = `${monthName}-${day}-${time}`;
+
+    if (assetClass === "priceBinary") {
+      const { targetPrice } = lookup;
+      if (!targetPrice) return null;
+      return `${underlying}-above-${targetPrice}-${side}-${dateStr}`.toLowerCase();
+    }
+
+    if (assetClass === "priceBucket") {
+      const { priceThresholds } = lookup;
+      if (!priceThresholds) return null;
+      const prices = priceThresholds.split(",");
+      if (prices.length !== 2) return null;
+
+      const bucketStr = outcomeIndex === 0
+        ? `below-${prices[0]}`
+        : outcomeIndex === 1
+        ? `${prices[0]}-to-${prices[1]}`
+        : `above-${prices[1]}`;
+
+      return `${underlying}-price-range-${dateStr}-${bucketStr}-${side}`.toLowerCase();
+    }
+    return null;
+  }
+
   /**
    * Get asset ID for a coin.
    * - For Perpetuals, use the coin name (e.g., "BTC").
@@ -207,6 +330,13 @@ export class SymbolConverter {
    * converter.getAssetId("BTC"); // → 0
    * converter.getAssetId("HYPE/USDC"); // → 10107
    * converter.getAssetId("test:ABC"); // → 110000
+   * // Can also be used to retrieve the assetId of outcome markets using the same slug as in the URL
+   * // Examples:
+   * // For binary outcome markets: btc-above-81041-yes-may-08-0600
+   * // For multi-price outcome markets:
+   * //     btc-price-range-may-08-0600-below-79303-yes
+   * //     btc-price-range-may-08-0600-79303-to-82540-yes
+   * //     btc-price-range-may-08-0600-above-82540-yes
    * ```
    */
   getAssetId(name: string): number | undefined {

--- a/src/utils/_symbolConverter.ts
+++ b/src/utils/_symbolConverter.ts
@@ -20,7 +20,7 @@ export interface SymbolConverterOptions {
 
 /**
  * Utility class for converting asset symbols to their corresponding IDs and size decimals.
- * Supports perpetuals, spot markets, and optional builder dexs.
+ * Supports perpetuals, spots, optional builder dexs and outcome markets.
  *
  * @example
  * ```ts
@@ -34,11 +34,12 @@ export interface SymbolConverterOptions {
  * // const converter = await SymbolConverter.create({ transport, dexs: ["test"] });
  *
  * const btcId = converter.getAssetId("BTC"); // perpetual → 0
- * const hypeUsdcId = converter.getAssetId("HYPE/USDC"); // spot market → 10107
+ * const hypeUsdcId = converter.getAssetId("HYPE/USDC"); // spot → 10107
  * const dexAbcId = converter.getAssetId("test:ABC"); // builder dex (if enabled) → 110000
+ * const outcomeId = converter.getAssetId("btc-above-61720-yes-jun-08-0600"); // outcome market → 100002200
  *
  * const btcSzDecimals = converter.getSzDecimals("BTC"); // perpetual → 5
- * const hypeUsdcSzDecimals = converter.getSzDecimals("HYPE/USDC"); // spot market → 2
+ * const hypeUsdcSzDecimals = converter.getSzDecimals("HYPE/USDC"); // spot → 2
  * const dexAbcSzDecimals = converter.getSzDecimals("test:ABC"); // builder dex (if enabled) → 0
  *
  * const spotPairId = converter.getSpotPairId("HFUN/USDC"); // → "@2"
@@ -104,52 +105,68 @@ export class SymbolConverter {
       outcomeMeta(config),
     ]);
 
-    if (!perpMetaData?.universe?.length) {
-      throw new Error("Invalid perpetual metadata response");
-    }
-
-    if (!spotMetaData?.universe?.length || !spotMetaData?.tokens?.length) {
-      throw new Error("Invalid spot metadata response");
-    }
-
     this._nameToAssetId.clear();
     this._nameToSzDecimals.clear();
     this._nameToSpotPairId.clear();
     this._spotPairIdToName.clear();
 
-    this._processDefaultPerps(perpMetaData);
-    this._processSpotAssets(spotMetaData);
-    this._processAllRecurringOutcomeAssets(outcomeMetaData);
-
-    // Only process builder dexs if dex support is enabled
-    if (perpDexsData) {
-      await this._processBuilderDexs(perpDexsData);
-    }
+    this._processPerps(perpMetaData);
+    this._processSpot(spotMetaData);
+    this._processOutcomeMarkets(outcomeMetaData);
+    if (perpDexsData) await this._processBuilderDexs(perpDexsData);
   }
 
-  private _processDefaultPerps(perpMetaData: MetaResponse): void {
+  // ============================================================
+  // Perpetuals
+  // ============================================================
+
+  private _processPerps(perpMetaData: MetaResponse): void {
     perpMetaData.universe.forEach((asset, index) => {
       this._nameToAssetId.set(asset.name, index);
       this._nameToSzDecimals.set(asset.name, asset.szDecimals);
     });
   }
 
-  private async _processBuilderDexs(perpDexsData: PerpDexsResponse): Promise<void> {
-    if (!perpDexsData || perpDexsData.length <= 1) return;
+  // ============================================================
+  // Spot
+  // ============================================================
 
+  private _processSpot(spotMetaData: SpotMetaResponse): void {
+    const tokenMap = new Map<number, { name: string; szDecimals: number }>();
+    spotMetaData.tokens.forEach((token) => {
+      tokenMap.set(token.index, { name: token.name, szDecimals: token.szDecimals });
+    });
+
+    spotMetaData.universe.forEach((market) => {
+      const baseToken = tokenMap.get(market.tokens[0]);
+      const quoteToken = tokenMap.get(market.tokens[1]);
+      if (!baseToken || !quoteToken) return;
+
+      const assetId = 10000 + market.index;
+      const baseQuoteKey = `${baseToken.name}/${quoteToken.name}`;
+
+      this._nameToAssetId.set(baseQuoteKey, assetId);
+      this._nameToSzDecimals.set(baseQuoteKey, baseToken.szDecimals);
+      this._nameToSpotPairId.set(baseQuoteKey, market.name);
+      this._spotPairIdToName.set(market.name, baseQuoteKey);
+    });
+  }
+
+  // ============================================================
+  // Builder dexs
+  // ============================================================
+
+  private async _processBuilderDexs(perpDexsData: PerpDexsResponse): Promise<void> {
     const builderDexs = perpDexsData
       .map((dex, index) => ({ dex, index }))
       .filter((item): item is { dex: NonNullable<PerpDexsResponse[number]>; index: number } => {
         return item.index > 0 && item.dex !== null && item.dex.name.length > 0;
       });
-
     if (builderDexs.length === 0) return;
 
-    // Filter dexs based on the dexOption
     const dexsToProcess = Array.isArray(this._dexOption)
       ? builderDexs.filter((item) => (this._dexOption as string[]).includes(item.dex.name))
-      : builderDexs; // true means process all
-
+      : builderDexs;
     if (dexsToProcess.length === 0) return;
 
     const config = { transport: this._transport };
@@ -159,47 +176,29 @@ export class SymbolConverter {
 
     results.forEach((result, idx) => {
       if (result.status !== "fulfilled") return;
-      this._processBuilderDexResult(result.value, dexsToProcess[idx].index);
+
+      const dexIndex = dexsToProcess[idx].index;
+      const offset = 100000 + dexIndex * 10000;
+
+      result.value.universe.forEach((asset, index) => {
+        const assetId = offset + index;
+        this._nameToAssetId.set(asset.name, assetId);
+        this._nameToSzDecimals.set(asset.name, asset.szDecimals);
+      });
     });
   }
 
-  private _processBuilderDexResult(dexMeta: MetaResponse, perpDexIndex: number): void {
-    const offset = 100000 + perpDexIndex * 10000;
+  // ============================================================
+  // Outcome markets
+  // ============================================================
 
-    dexMeta.universe.forEach((asset, index) => {
-      const assetId = offset + index;
-      this._nameToAssetId.set(asset.name, assetId);
-      this._nameToSzDecimals.set(asset.name, asset.szDecimals);
-    });
-  }
-
-  private _processSpotAssets(spotMetaData: SpotMetaResponse): void {
-    const tokenMap = new Map<number, { name: string; szDecimals: number }>();
-    spotMetaData.tokens.forEach((token) => {
-      tokenMap.set(token.index, { name: token.name, szDecimals: token.szDecimals });
-    });
-
-    spotMetaData.universe.forEach((market) => {
-      if (market.tokens.length < 2) return;
-      const baseToken = tokenMap.get(market.tokens[0]);
-      const quoteToken = tokenMap.get(market.tokens[1]);
-      if (!baseToken || !quoteToken) return;
-
-      const assetId = 10000 + market.index;
-      const baseQuoteKey = `${baseToken.name}/${quoteToken.name}`;
-      this._nameToAssetId.set(baseQuoteKey, assetId);
-      this._nameToSzDecimals.set(baseQuoteKey, baseToken.szDecimals);
-      this._nameToSpotPairId.set(baseQuoteKey, market.name);
-      this._spotPairIdToName.set(market.name, baseQuoteKey);
-    });
-  }
-
-  private _processAllRecurringOutcomeAssets(outcomeMetaData: OutcomeMetaResponse): void {
+  private _processOutcomeMarkets(outcomeMetaData: OutcomeMetaResponse): void {
     this._processBinaryOutcomeAssets(outcomeMetaData);
     this._processRecurringBucketOutcomeAssets(outcomeMetaData);
   }
+
   /**
-   * Handle the population of binary(priceBinary) outcome market slugs
+   * Populates binary (`priceBinary`) outcome market slugs.
    */
   private _processBinaryOutcomeAssets(outcomeMetaData: OutcomeMetaResponse): void {
     outcomeMetaData.outcomes.forEach((outcome) => {
@@ -218,7 +217,7 @@ export class SymbolConverter {
   }
 
   /**
-   * Handle the population of multi-price(priceBucket) outcome market slugs
+   * Populates multi-price (`priceBucket`) outcome market slugs.
    */
   private _processRecurringBucketOutcomeAssets(outcomeMetaData: OutcomeMetaResponse): void {
     outcomeMetaData.questions.forEach((question) => {
@@ -245,8 +244,9 @@ export class SymbolConverter {
   }
 
   /**
-   * Map the slug to the assetId as per the specification:
-   * {@link https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/asset-ids}
+   * Maps the slug to the assetId as per the specification.
+   *
+   * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/asset-ids
    */
   private _populateIndividualBucketOutcome(
     outcomeId: number,
@@ -264,12 +264,14 @@ export class SymbolConverter {
   }
 
   /**
-   * Generate the appropiate slug for binary and multi-price(bucket) outcome markets
-   * {@link https://hyperliquid.gitbook.io/hyperliquid-docs/trading/contract-specifications}
-   * @param description complete description of an outcome
-   * @param side for the requested slug retrieved from the sideSpecs
-   * @param outcomeIndex for the classification of the bucket: (0 -> below, 1-between, 2-above)
-   * @returns the generated slug
+   * Generates the appropriate slug for binary and multi-price (bucket) outcome markets.
+   *
+   * @param description Complete description of an outcome.
+   * @param side Side name retrieved from the sideSpecs.
+   * @param outcomeIndex Bucket classification (0 = below, 1 = between, 2 = above).
+   * @return The generated slug.
+   *
+   * @see https://hyperliquid.gitbook.io/hyperliquid-docs/trading/contract-specifications
    */
   private _descriptionToSlug(description: string, side: string, outcomeIndex: number): string | null {
     const parts = description.split("|");
@@ -313,11 +315,16 @@ export class SymbolConverter {
     return null;
   }
 
+  // ============================================================
+  // Public API
+  // ============================================================
+
   /**
    * Get asset ID for a coin.
    * - For Perpetuals, use the coin name (e.g., "BTC").
-   * - For Spot markets, use the "BASE/QUOTE" format (e.g., "HYPE/USDC").
-   * - For Builder Dex assets, use the "DEX_NAME:ASSET_NAME" format (e.g., "test:ABC").
+   * - For Spots, use the "BASE/QUOTE" format (e.g., "HYPE/USDC").
+   * - For Builder Dexs, use the "DEX_NAME:ASSET_NAME" format (e.g., "test:ABC").
+   * - For Outcome Markets, use the slug as in the URL (e.g., "btc-above-61720-yes-jun-08-0600").
    *
    * @example
    * ```ts
@@ -330,13 +337,7 @@ export class SymbolConverter {
    * converter.getAssetId("BTC"); // → 0
    * converter.getAssetId("HYPE/USDC"); // → 10107
    * converter.getAssetId("test:ABC"); // → 110000
-   * // Can also be used to retrieve the assetId of outcome markets using the same slug as in the URL
-   * // Examples:
-   * // For binary outcome markets: btc-above-81041-yes-may-08-0600
-   * // For multi-price outcome markets:
-   * //     btc-price-range-may-08-0600-below-79303-yes
-   * //     btc-price-range-may-08-0600-79303-to-82540-yes
-   * //     btc-price-range-may-08-0600-above-82540-yes
+   * converter.getAssetId("btc-above-61720-yes-jun-08-0600"); // → 100002200
    * ```
    */
   getAssetId(name: string): number | undefined {
@@ -346,8 +347,8 @@ export class SymbolConverter {
   /**
    * Get size decimals for a coin.
    * - For Perpetuals, use the coin name (e.g., "BTC").
-   * - For Spot markets, use the "BASE/QUOTE" format (e.g., "HYPE/USDC").
-   * - For Builder Dex assets, use the "DEX_NAME:ASSET_NAME" format (e.g., "test:ABC").
+   * - For Spots, use the "BASE/QUOTE" format (e.g., "HYPE/USDC").
+   * - For Builder Dexs, use the "DEX_NAME:ASSET_NAME" format (e.g., "test:ABC").
    *
    * @example
    * ```ts
@@ -367,9 +368,7 @@ export class SymbolConverter {
   }
 
   /**
-   * Get spot pair ID for info endpoints and subscriptions (e.g., l2book, trades).
-   *
-   * Accepts spot markets in the "BASE/QUOTE" format (e.g., "HFUN/USDC").
+   * Get spot pair ID (e.g., @2) for info endpoints and subscriptions (e.g., l2book, trades).
    *
    * @example
    * ```ts
@@ -388,9 +387,7 @@ export class SymbolConverter {
   }
 
   /**
-   * Get the symbol ("BASE/QUOTE") from a spot pair ID.
-   *
-   * Accepts pair IDs such as "@107" or "PURR/USDC".
+   * Get the symbol ("BASE/QUOTE") from a spot pair ID (e.g., @107).
    *
    * @example
    * ```ts
@@ -401,7 +398,7 @@ export class SymbolConverter {
    * const converter = await SymbolConverter.create({ transport });
    *
    * converter.getSymbolBySpotPairId("@107"); // → "HYPE/USDC"
-   * converter.getSymbolBySpotPairId("PURR/USDC"); // → "PURR/USDC"
+   * converter.getSymbolBySpotPairId("PURR/USDC"); // → "PURR/USDC" (exceptions exist for some pairs)
    * ```
    */
   getSymbolBySpotPairId(pairId: string): string | undefined {

--- a/tests/utils/symbolConverter.test.ts
+++ b/tests/utils/symbolConverter.test.ts
@@ -1,8 +1,29 @@
 // deno-lint-ignore-file no-import-prefix
 
 import { assertEquals } from "jsr:@std/assert@1";
-import { HttpTransport } from "@nktkas/hyperliquid";
+import { HttpTransport, type IRequestTransport } from "@nktkas/hyperliquid";
 import { SymbolConverter } from "@nktkas/hyperliquid/utils";
+import type { OutcomeMetaResponse } from "@nktkas/hyperliquid/api/info";
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/** Builds a request transport that serves a fixed `outcomeMeta` and empty perpetual/spot metadata. */
+function createOutcomeTransport(outcomeMeta: OutcomeMetaResponse): IRequestTransport {
+  const responses: Record<string, unknown> = {
+    meta: { universe: [] },
+    spotMeta: { tokens: [], universe: [] },
+    outcomeMeta,
+  };
+  return {
+    isTestnet: false,
+    request<T>(_endpoint: "info" | "exchange" | "explorer", payload: unknown): Promise<T> {
+      const { type } = payload as { type: string };
+      return Promise.resolve(responses[type] as T);
+    },
+  };
+}
 
 // ============================================================
 // Test Data
@@ -22,6 +43,73 @@ const DEX_EXPECTATIONS = {
   "test:ABC": { assetId: 110000 },
   "unit:ES": { assetId: 120000 },
 } as const;
+
+/** A trimmed `outcomeMeta` response covering every supported market type, modeled on real mainnet data. */
+const OUTCOME_META: OutcomeMetaResponse = {
+  outcomes: [
+    {
+      outcome: 220,
+      name: "Recurring",
+      description: "class:priceBinary|underlying:BTC|expiry:20260608-0600|targetPrice:61720|period:1d",
+      sideSpecs: [{ name: "Yes" }, { name: "No" }],
+    },
+    {
+      outcome: 222,
+      name: "Recurring Named Outcome",
+      description: "index:0",
+      sideSpecs: [{ name: "Yes" }, { name: "No" }],
+    },
+    {
+      outcome: 223,
+      name: "Recurring Named Outcome",
+      description: "index:1",
+      sideSpecs: [{ name: "Yes" }, { name: "No" }],
+    },
+    {
+      outcome: 224,
+      name: "Recurring Named Outcome",
+      description: "index:2",
+      sideSpecs: [{ name: "Yes" }, { name: "No" }],
+    },
+    {
+      outcome: 170,
+      name: "NBA Finals Game 3",
+      description: "metadata=category:sports|subCategory:basketball",
+      sideSpecs: [{ name: "San Antonio" }, { name: "New York" }],
+    },
+    { outcome: 173, name: "Argentina", description: "", sideSpecs: [{ name: "Yes" }, { name: "No" }] },
+    { outcome: 101, name: "Below 4.3%", description: "", sideSpecs: [{ name: "Yes" }, { name: "No" }] },
+    { outcome: 100, name: "Fallback", description: "", sideSpecs: [{ name: "Yes" }, { name: "No" }] },
+    { outcome: 171, name: "Fallback", description: "", sideSpecs: [{ name: "Yes" }, { name: "No" }] },
+    { outcome: 221, name: "Recurring Fallback", description: "", sideSpecs: [{ name: "Yes" }, { name: "No" }] },
+  ],
+  questions: [
+    {
+      question: 33,
+      name: "Recurring",
+      description: "class:priceBucket|underlying:BTC|expiry:20260608-0600|priceThresholds:60485,62954|period:1d",
+      fallbackOutcome: 221,
+      namedOutcomes: [222, 223, 224],
+      settledNamedOutcomes: [],
+    },
+    {
+      question: 32,
+      name: "2026 World Cup Champion",
+      description: "",
+      fallbackOutcome: 171,
+      namedOutcomes: [173],
+      settledNamedOutcomes: [],
+    },
+    {
+      question: 19,
+      name: "May CPI year-over-year",
+      description: "",
+      fallbackOutcome: 100,
+      namedOutcomes: [101],
+      settledNamedOutcomes: [],
+    },
+  ],
+};
 
 // ============================================================
 // Tests
@@ -132,5 +220,43 @@ Deno.test("SymbolConverter", async (t) => {
       assertEquals(conv.getAssetId("test:ABC"), DEX_EXPECTATIONS["test:ABC"].assetId);
       assertEquals(conv.getAssetId("unit:ES"), DEX_EXPECTATIONS["unit:ES"].assetId);
     });
+  });
+});
+
+Deno.test("SymbolConverter outcome markets", async (t) => {
+  const converter = await SymbolConverter.create({ transport: createOutcomeTransport(OUTCOME_META) });
+
+  await t.step("getAssetId()", async (t) => {
+    await t.step("recurring binary", () => {
+      assertEquals(converter.getAssetId("btc-above-61720-yes-jun-08-0600"), 100002200);
+      assertEquals(converter.getAssetId("btc-above-61720-no-jun-08-0600"), 100002201);
+    });
+
+    await t.step("recurring bucket", () => {
+      assertEquals(converter.getAssetId("btc-price-range-jun-08-0600-below-60485-yes"), 100002220);
+      assertEquals(converter.getAssetId("btc-price-range-jun-08-0600-60485-to-62954-yes"), 100002230);
+      assertEquals(converter.getAssetId("btc-price-range-jun-08-0600-above-62954-yes"), 100002240);
+    });
+
+    await t.step("sports", () => {
+      assertEquals(converter.getAssetId("nba-finals-game-3-san-antonio"), 100001700);
+      assertEquals(converter.getAssetId("nba-finals-game-3-new-york"), 100001701);
+    });
+
+    await t.step("categorical", () => {
+      assertEquals(converter.getAssetId("2026-world-cup-champion-argentina-yes"), 100001730);
+      assertEquals(converter.getAssetId("2026-world-cup-champion-argentina-no"), 100001731);
+      assertEquals(converter.getAssetId("may-cpi-year-over-year-below-43-yes"), 100001010);
+    });
+
+    await t.step("fallback outcomes are skipped", () => {
+      assertEquals(converter.getAssetId("fallback"), undefined);
+      assertEquals(converter.getAssetId("recurring-fallback"), undefined);
+    });
+  });
+
+  await t.step("getSzDecimals()", () => {
+    assertEquals(converter.getSzDecimals("nba-finals-game-3-san-antonio"), 5);
+    assertEquals(converter.getSzDecimals("2026-world-cup-champion-argentina-yes"), 5);
   });
 });


### PR DESCRIPTION
**Description of the Desired Feature**
This PR introduces support for both priceBinary and priceBucket recurring outcomes inside the symbolConverter. It adds full support for generating slugs (identical to the ones used for web URLs) and mapping them to their corresponding assetIds, in accordance with the Hyperliquid documentation for [Asset IDs](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/asset-ids) and [Contract Specifications](https://hyperliquid.gitbook.io/hyperliquid-docs/trading/contract-specifications).

**Motivation and Use Case**
Provide a standardized and human friendly way of retrieving assetIds (and eventually other information) about the new HIP4 outcome markets using the hyperliquid URL slug format.

**Proposed Solution**
I introduced the main orchestrator: _processAllRecurringAssets (which can be easily isolated or toggled via a flag if required). This orchestrator delegates to specific processors depending on how the market data is structured:
- _processBinaryOutcomeAssets: Handles binary markets where data is provided directly inside the outcomes field of outcomeMeta.
- _processRecurringBucketOutcomeAssets: Handles multi-price bucket markets. Because bucket responses are standardized, this processor iterates through the questions field and maps the namedOutcomes array to the corresponding entries inside the outcomes array. This makes it straightforward to generate all possible slugs.

**Additional Information**
Testing limitations: There currently isn't an easy way to write static tests for this feature because the slugs dynamically change based on the day/month. Additionally, the testnet does not provide fixed, long-term markets to test against, so validation requires separate handling.

Scope of the implementation: Support is currently limited to the officially documented recurring outcome markets (so what mainnet does). It does not handle non-standardized testnet cases (for example, the market "What will Hypurr eat the most of in May 2026?", where the name field contains the actual question rather than "Recurring"). These non-standard cases will require separate handling.

Extra: There doesn't seem to be a way to retrieve the getSzDecimals value for a given token, however this seems to be 5 for all markets (which would make sense, considering the nature of the markets), however i've decied not to hardcode this as it doesn't seem to be specified anywhere.

Below is attached a screenshot of the slug->asssetId mapping for currently avaialble mainnet markets:
<img width="726" height="213" alt="image" src="https://github.com/user-attachments/assets/5fa5e6e2-05a5-4765-b40f-e859cff428eb" />
