### PR TITLE
Fix large decimal price formatting

### DIFF
--- a/src/utils/_format.ts
+++ b/src/utils/_format.ts
@@ -77,21 +77,17 @@ const StringMath = {
   log10Floor(value: string): number {
     const abs = value[0] === "-" ? value.slice(1) : value;
 
-    // Check if zero or invalid
-    const num = Number(abs);
-    if (num === 0 || isNaN(num)) return -Infinity;
-
-    const [int, dec] = abs.split(".");
+    const [int, dec = ""] = abs.split(".");
+    const trimmedInt = int.replace(/^0+/, "");
 
     // Number >= 1: magnitude = length of integer part - 1
-    if (Number(int) !== 0) {
-      const trimmed = int.replace(/^0+/, "");
-      return trimmed.length - 1;
+    if (trimmedInt.length > 0) {
+      return trimmedInt.length - 1;
     }
 
     // Number < 1: count leading zeros in decimal part
-    const leadingZeros = dec.match(/^0*/)?.[0].length ?? 0;
-    return -(leadingZeros + 1);
+    const firstNonZeroDecimal = dec.search(/[1-9]/);
+    return firstNonZeroDecimal === -1 ? -Infinity : -(firstNonZeroDecimal + 1);
   },
 
   /** Multiply by 10^exp: shift decimal point left (negative) or right (positive). */

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -36,6 +36,10 @@ Deno.test("formatPrice", async (t) => {
       assertEquals(formatPrice("12345.6", 0), "12345");
       assertEquals(formatPrice("0.00123456", 0), "0.001234");
     });
+
+    await t.step("handles very large decimal strings without precision loss", () => {
+      assertEquals(formatPrice("123456789012345678901234567890.123", 0), "123450000000000000000000000000");
+    });
   });
 
   await t.step("decimal limits", async (t) => {


### PR DESCRIPTION
Fixes precision loss when formatting very large decimal strings.

`StringMath.log10Floor()` currently converts the integer portion through `Number(...)` to decide whether the value is >= 1. For very large decimal strings this loses arbitrary-precision behavior and can also overflow to `Infinity`, while the rest of the formatter is string-based.

This derives the magnitude directly from string digits instead, and adds a regression test for a large decimal price.

I could not run the Deno test locally because `deno` is not installed in my environment.