### PR TITLE
fix(utils): allow integer prices written with trailing decimal zeros in formatPrice

### DIFF
--- a/src/utils/_format.ts
+++ b/src/utils/_format.ts
@@ -29,6 +29,14 @@ export function formatPrice(price: string | number, szDecimals: number, type: "p
   const maxDecimals = Math.max((type === "perp" ? 6 : 8) - szDecimals, 0);
   price = StringMath.toFixedTruncate(price, maxDecimals);
 
+  // Integer prices are always allowed, including values that become integers
+  // after decimal truncation (e.g. "100001.0" -> "100001"). Without this
+  // re-check the significant-figure step below would truncate them (-> "100000").
+  // A value that truncated all the way to zero is left for the zero check below.
+  if (/^-?\d+$/.test(price) && !/^-?0+$/.test(price)) {
+    return formatDecimalString(price);
+  }
+
   // Apply sig figs limit: max 5 significant figures
   price = StringMath.toPrecisionTruncate(price, 5);
 

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -32,6 +32,14 @@ Deno.test("formatPrice", async (t) => {
       assertEquals(formatPrice("1234567", 0), "1234567");
     });
 
+    await t.step("integer value with trailing decimal zeros bypasses limit", () => {
+      assertEquals(formatPrice("100001.0", 0), "100001");
+      assertEquals(formatPrice("123456.0", 0), "123456");
+      assertEquals(formatPrice("100001.00", 0), "100001");
+      assertEquals(formatPrice("-123456.0", 0), "-123456");
+      assertEquals(formatPrice("100001.0", 0, "spot"), "100001");
+    });
+
     await t.step("truncates to 5 sig figs", () => {
       assertEquals(formatPrice("12345.6", 0), "12345");
       assertEquals(formatPrice("0.00123456", 0), "0.001234");


### PR DESCRIPTION
## Bug

`formatPrice` documents that **"integer prices are always allowed regardless of significant figures"** and bypasses the 5-significant-figure truncation when the input matches `/^-?\d+$/`. That check only runs on the **raw** input, so a price that is integer-valued but written with a trailing decimal (e.g. `"100001.0"`) fails the regex, falls through to `toFixedTruncate` (which strips the `.0`, yielding `"100001"`), and is then truncated by the sig-fig step to `"100000"`.

The same integer price produces different output depending on how it was formatted:

```ts
formatPrice("100001",    0) // "100001"   ok
formatPrice("100001.0",  0) // "100000"   wrong, off by 1
formatPrice("123456.0",  0) // "123450"   wrong
formatPrice("-123456.0", 0) // "-123450"  wrong
formatPrice("100001.00", 0) // "100000"   wrong
```

A float-derived price submitted as a string (e.g. `(100001).toFixed(1)` -> `"100001.0"`, or any value that carries a trailing zero) therefore places an order at a **different price than intended** - a direct mispricing on high-value assets.

## Fix

Re-check the integer-bypass condition **after** `toFixedTruncate`, so a value that has become an integer is treated the same as a raw integer input. A value that truncated all the way to zero is excluded, so the existing "price too small" `RangeError` still fires.

```ts
price = StringMath.toFixedTruncate(price, maxDecimals);

// Integer prices are always allowed, including values that became integers
// after decimal truncation (e.g. "100001.0" -> "100001").
if (/^-?\d+$/.test(price) && !/^-?0+$/.test(price)) {
  return formatDecimalString(price);
}

price = StringMath.toPrecisionTruncate(price, 5);
```

## Tests

Added regression cases to `tests/utils/format.test.ts`:

```ts
assertEquals(formatPrice("100001.0", 0), "100001");
assertEquals(formatPrice("123456.0", 0), "123456");
assertEquals(formatPrice("100001.00", 0), "100001");
assertEquals(formatPrice("-123456.0", 0), "-123456");
assertEquals(formatPrice("100001.0", 0, "spot"), "100001");
```

## Verification (local)

- The new cases **fail on `main`** (return `"100000"` / `"123450"`) and **pass** with this change.
- The full `formatPrice` + `formatSize` suite stays green (46 steps, including the reference-asset validation against PURR/DYDX/SOL/BNB/ETH/BTC and the spot pairs).
- The "price too small -> RangeError" edge case still throws (`formatPrice("0.0000001", 0)`), and non-integer truncation is unchanged (`formatPrice("100000.5", 0)` -> `"100000"`, `formatPrice("12345.6", 0)` -> `"12345"`).
- `deno fmt --check` and `deno lint` are clean.
