### PR TITLE
feat(subscription/l2Book): add optional 'fast' field

### DIFF
--- a/src/api/subscription/_methods/l2Book.ts
+++ b/src/api/subscription/_methods/l2Book.ts
@@ -18,6 +18,8 @@ export const L2BookRequest = /* @__PURE__ */ (() => {
     nSigFigs: v.nullish(v.picklist([2, 3, 4, 5])),
     /** Mantissa for aggregation (if `nSigFigs` is 5). */
     mantissa: v.nullish(v.picklist([2, 5])),
+    //** How fast the snapshots should be pushed (if `fast` is true 5 levels every 0.5 seconds else 20 levels every 2 seconds) */
+    fast: v.nullish(v.boolean(), false),
   });
 })();
 export type L2BookRequest = v.InferOutput<typeof L2BookRequest>;
@@ -110,6 +112,7 @@ export function l2Book(
     ...params,
     nSigFigs: params.nSigFigs ?? null,
     mantissa: params.mantissa ?? null,
+    fast: params.fast ?? null,
   });
   return config.transport.subscribe<L2BookEvent>(payload.type, payload, (e) => {
     if (e.detail.coin === payload.coin) {

--- a/src/api/subscription/_methods/l2Book.ts
+++ b/src/api/subscription/_methods/l2Book.ts
@@ -18,8 +18,12 @@ export const L2BookRequest = /* @__PURE__ */ (() => {
     nSigFigs: v.nullish(v.picklist([2, 3, 4, 5])),
     /** Mantissa for aggregation (if `nSigFigs` is 5). */
     mantissa: v.nullish(v.picklist([2, 5])),
-    //** How fast the snapshots should be pushed (if `fast` is true 5 levels every 0.5 seconds else 20 levels every 2 seconds) */
-    fast: v.nullish(v.boolean(), false),
+    /**
+     * Whether to receive faster, shallower order book snapshots.
+     * - `true`: 5 levels every 0.5 seconds.
+     * - `false`: 20 levels every 5 seconds.
+     */
+    fast: v.optional(v.boolean()),
   });
 })();
 export type L2BookRequest = v.InferOutput<typeof L2BookRequest>;
@@ -60,6 +64,8 @@ export type L2BookEvent = {
    * @pattern ^[0-9]+(\.[0-9]+)?$
    */
   spread?: string;
+  /** Indicates a fast-mode snapshot (only present when subscribed with `fast: true`). */
+  fast?: true;
 };
 
 // ============================================================
@@ -112,7 +118,6 @@ export function l2Book(
     ...params,
     nSigFigs: params.nSigFigs ?? null,
     mantissa: params.mantissa ?? null,
-    fast: params.fast ?? null,
   });
   return config.transport.subscribe<L2BookEvent>(payload.type, payload, (e) => {
     if (e.detail.coin === payload.coin) {

--- a/tests/api/subscription/l2Book.test.ts
+++ b/tests/api/subscription/l2Book.test.ts
@@ -21,7 +21,6 @@ runTest({
       { coin: "BTC", nSigFigs: 5, mantissa: 2 },
       { coin: "BTC", nSigFigs: 5, mantissa: 5 },
       { coin: "BTC", nSigFigs: null, mantissa: null },
-      { coin: "BTC", nSigFigs: null, mantissa: null, fast: null },
       { coin: "ETH", fast: false },
       { coin: "ETH", fast: true },
     ];

--- a/tests/api/subscription/l2Book.test.ts
+++ b/tests/api/subscription/l2Book.test.ts
@@ -21,6 +21,9 @@ runTest({
       { coin: "BTC", nSigFigs: 5, mantissa: 2 },
       { coin: "BTC", nSigFigs: 5, mantissa: 5 },
       { coin: "BTC", nSigFigs: null, mantissa: null },
+      { coin: "BTC", nSigFigs: null, mantissa: null, fast: null },
+      { coin: "ETH", fast: false },
+      { coin: "ETH", fast: true },
     ];
 
     const data = await collectEventsOverTime<L2BookEvent>(async (cb) => {


### PR DESCRIPTION
**What & why**

Add the optional **'fast'** field in the websocket subscription schema of **L2BookRequest**.
The field changes the manner in which the responses are pushed("5 levels if fast, 20 levels if slow")->[docs (search for l2Book)](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions) 
Via telegram Hyperliquid API Announcements(@hyperliquid_api) : 
- "l2Book subscriptions will include an optional fast: true field. When set, the book will push 5 levels every 0.5 seconds The subscription without the flag will push 20 levels every ~5 seconds~" (https://t.me/hyperliquid_api/326). 
- This was however change to based on feedback: "l2Book without fast: true will push 20 levels every 2 seconds, instead of every 5 seconds"(https://t.me/hyperliquid_api/327)

**Type of change**

- [ ] Bug fix
- [ ] New API method / feature
- [x] Schema/type update to match the Hyperliquid API
- [ ] Breaking change
