### PR TITLE
refactor(utils)!: rework price and size formatting

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -51,7 +51,8 @@
     "@noble/hashes": "jsr:@noble/hashes@^2.2.0",
     "@std/async/unstable-semaphore": "jsr:@std/async@1.4.0/unstable-semaphore",
     "@std/msgpack/encode": "jsr:@std/msgpack@^1.0.3/encode",
-    "@valibot/valibot": "jsr:@valibot/valibot@^1.4.1"
+    "@valibot/valibot": "jsr:@valibot/valibot@^1.4.1",
+    "decimal.js": "npm:decimal.js@^10.6.0"
   },
   "lock": false
 }

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -11,6 +11,7 @@ Every exception the SDK itself throws extends `HyperliquidError`. One `instanceo
 Error
 └─ HyperliquidError
    ├─ ValidationError
+   ├─ FormatError
    ├─ AbstractWalletError
    ├─ CanonicalizeError
    ├─ ApiRequestError
@@ -22,6 +23,7 @@ Error
 | Class                   | Thrown from                                      | Inspect                   |
 | ----------------------- | ------------------------------------------------ | ------------------------- |
 | `ValidationError`       | Schema parsing, before any network I/O           | `message`, `cause.issues` |
+| `FormatError`           | `formatPrice` / `formatSize`, before network I/O | `message`                 |
 | `AbstractWalletError`   | Signing layer (viem / ethers / custom adapter)   | `cause`                   |
 | `CanonicalizeError`     | `canonicalize()` helper during low-level signing | `message`                 |
 | `ApiRequestError`       | Hyperliquid API returned an error response       | `message`, `response`     |
@@ -44,6 +46,23 @@ try {
   if (error instanceof ValidationError) {
     console.error(error.message);      // human-readable summary
     console.error(error.cause.issues); // path + expected + received per issue
+  }
+}
+```
+
+## `FormatError`
+
+Thrown by the [`formatPrice` and `formatSize`](utilities.md) helpers when a value cannot be turned into a valid
+Hyperliquid price or size — the input is not a finite number, or truncation collapses it to `0`.
+
+```ts
+import { FormatError, formatPrice } from "@nktkas/hyperliquid/utils";
+
+try {
+  formatPrice("not a number", 0);
+} catch (error) {
+  if (error instanceof FormatError) {
+    console.error(error.message); // what was invalid
   }
 }
 ```
@@ -209,13 +228,17 @@ import {
   ValidationError,
   WebSocketRequestError,
 } from "@nktkas/hyperliquid";
+import { FormatError, formatPrice } from "@nktkas/hyperliquid/utils";
 
 try {
-  await client.order({ orders: [/* ... */], grouping: "na" });
+  const price = formatPrice("65000.1", 3);
+  await client.order({ orders: [{ p: price /* ... */ }] });
 } catch (error) {
   if (error instanceof HyperliquidError) {
     if (error instanceof ValidationError) {
       // invalid parameters — inspect error.message
+    } else if (error instanceof FormatError) {
+      // price or size could not be formatted — inspect error.message
     } else if (error instanceof ApiRequestError) {
       // API rejected the action — inspect error.message
     } else if (error instanceof AbstractWalletError) {

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -21,7 +21,7 @@ Hyperliquid's tick and lot size rules constrain every order price to three condi
 - At most **`6 − szDecimals`** decimals for perpetuals, **`8 − szDecimals`** for spot.
 - Integer prices are always valid, regardless of significant figures.
 
-Use `formatPrice` — it applies both rules as a string operation, so arbitrary-precision inputs survive intact:
+Use `formatPrice` — it applies both rules with exact decimal arithmetic, so arbitrary-precision inputs survive intact:
 
 <!-- deno-fmt-ignore -->
 ```ts
@@ -47,7 +47,7 @@ rounds instead of truncating, ignores the significant-figures ceiling and has is
 {% hint style="warning" %}
 
 `formatPrice` **truncates**, it does not round. If truncation collapses a very small price to `0`, it throws
-`RangeError`.
+`FormatError`.
 
 {% endhint %}
 
@@ -70,8 +70,8 @@ formatSize("100", 0);         // "100"
 {% hint style="warning" %}
 
 Hyperliquid treats a literal `"0"` size on a reduce-only order as "close the whole position". `formatSize` refuses to
-return `"0"` (it throws `RangeError`), so if you actually want that behavior, pass `"0"` directly into the order payload
-instead of routing it through `formatSize`.
+return `"0"` (it throws `FormatError`), so if you actually want that behavior, pass `"0"` directly into the order
+payload instead of routing it through `formatSize`.
 
 {% endhint %}
 

--- a/src/api/_schemas.ts
+++ b/src/api/_schemas.ts
@@ -6,7 +6,6 @@
  */
 
 import * as v from "@valibot/valibot";
-import { formatDecimalString } from "../utils/_format.ts";
 
 // ============================================================
 // Number
@@ -18,7 +17,7 @@ export const UnsignedDecimal = /* @__PURE__ */ (() => {
     v.union([v.string(), v.number()]),
     v.toString(),
     v.string(), // HACK: for correct JSONSchema generation
-    v.transform((value) => formatDecimalString(value)),
+    v.transform((value) => normalizeDecimalString(value)),
     v.regex(/^[0-9]+(\.[0-9]+)?$/),
   );
 })();
@@ -30,7 +29,7 @@ export const Decimal = /* @__PURE__ */ (() => {
     v.union([v.string(), v.number()]),
     v.toString(),
     v.string(), // HACK: for correct JSONSchema generation
-    v.transform((value) => formatDecimalString(value)),
+    v.transform((value) => normalizeDecimalString(value)),
     v.regex(/^-?[0-9]+(\.[0-9]+)?$/),
   );
 })();
@@ -58,6 +57,35 @@ export const UnsignedInteger = /* @__PURE__ */ (() => {
   );
 })();
 export type UnsignedInteger = v.InferOutput<typeof UnsignedInteger>;
+
+/**
+ * Normalize a decimal string: drop redundant leading and trailing zeros and collapse negative zero.
+ * A string that is not a well-formed decimal is returned unchanged.
+ *
+ * @example
+ * ```ts ignore
+ * normalizeDecimalString("00123");  // => "123"
+ * normalizeDecimalString("1.2000"); // => "1.2"
+ * normalizeDecimalString(".5");     // => "0.5"
+ * normalizeDecimalString("-0.0");   // => "0"
+ * normalizeDecimalString("1.0.0");  // => "1.0.0" (not a decimal — unchanged)
+ * ```
+ */
+function normalizeDecimalString(value: string): string {
+  const match = value.match(/^(-?)([0-9]*)(?:\.([0-9]*))?$/);
+  if (!match) return value;
+  const [, sign, intRaw, fracRaw = ""] = match;
+  if (intRaw === "" && fracRaw === "") return value;
+
+  const int = intRaw.replace(/^0+/, "") || "0";
+
+  let fracEnd = fracRaw.length;
+  while (fracEnd > 0 && fracRaw[fracEnd - 1] === "0") fracEnd--;
+  const frac = fracRaw.slice(0, fracEnd);
+
+  const body = frac === "" ? int : `${int}.${frac}`;
+  return sign === "-" && body !== "0" ? `-${body}` : body;
+}
 
 // ============================================================
 // Hex

--- a/src/utils/_format.ts
+++ b/src/utils/_format.ts
@@ -1,4 +1,59 @@
 /**
+ * Price and size formatting per Hyperliquid tick and lot size rules.
+ *
+ * @module
+ */
+
+import { Decimal } from "decimal.js";
+import { HyperliquidError } from "../_base.ts";
+
+/**
+ * Thrown when a price or size value cannot be formatted to a valid decimal.
+ *
+ * @example
+ * ```ts
+ * import { formatPrice, FormatError } from "@nktkas/hyperliquid/utils";
+ *
+ * try {
+ *   formatPrice("not a number", 0);
+ * } catch (error) {
+ *   if (error instanceof FormatError) {
+ *     console.error(error.message);
+ *   }
+ * }
+ * ```
+ */
+export class FormatError extends HyperliquidError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "FormatError";
+  }
+}
+
+// A cloned constructor isolates our rounding mode from the global decimal.js
+// config, which any other consumer in the process could mutate via Decimal.set.
+const D = Decimal.clone({ rounding: Decimal.ROUND_DOWN });
+
+/**
+ * Parse a string or number into a finite decimal.js value.
+ *
+ * @throws {FormatError} If the value is unparsable or not finite.
+ */
+function toDecimal(value: string | number, field: "price" | "size"): Decimal {
+  let d: Decimal;
+  try {
+    d = new D(value);
+  } catch (cause) {
+    throw new FormatError(`Invalid ${field}: ${JSON.stringify(value)}`, { cause });
+  }
+  // decimal.js accepts NaN and Infinity as valid Decimals, so guard finiteness.
+  if (!d.isFinite()) {
+    throw new FormatError(`Invalid ${field}: ${String(value)} is not finite`);
+  }
+  return d;
+}
+
+/**
  * Format price according to Hyperliquid {@link https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/tick-and-lot-size | rules}:
  * - Maximum 5 significant figures
  * - Maximum 6 (for perp) or 8 (for spot) - `szDecimals` decimal places
@@ -9,34 +64,33 @@
  * @param type The market type: "perp" for perpetuals or "spot" for spot markets. Default: `"perp"`.
  * @return Formatted price string
  *
- * @throws {TypeError} If price is not a valid number string
- * @throws {RangeError} If the formatted price is 0
+ * @throws {FormatError} If the price is not a valid finite number, or is truncated to 0.
  *
  * @example
  * ```ts
  * import { formatPrice } from "@nktkas/hyperliquid/utils";
- * const price = formatPrice("0.0000123456789", 0, "spot"); // → "0.00001234"
+ *
+ * formatPrice("97123.456789", 0); // → "97123" (perp, szDecimals=0)
+ * formatPrice("1.23456789", 5); // → "1.2" (perp, szDecimals=5)
+ * formatPrice("0.0000123456789", 0, "spot"); // → "0.00001234" (spot, 8-decimal ceiling)
  * ```
  */
 export function formatPrice(price: string | number, szDecimals: number, type: "perp" | "spot" = "perp"): string {
-  price = price.toString().trim();
-  assertNumberString(price);
+  const d = toDecimal(price, "price");
 
-  // Integer prices are always allowed
-  if (/^-?\d+$/.test(price)) return formatDecimalString(price);
-
-  // Apply decimal limit: max 6 (perp) or 8 (spot) - szDecimals
   const maxDecimals = Math.max((type === "perp" ? 6 : 8) - szDecimals, 0);
-  price = StringMath.toFixedTruncate(price, maxDecimals);
+  let result = d.toDecimalPlaces(maxDecimals);
 
-  // Apply sig figs limit: max 5 significant figures
-  price = StringMath.toPrecisionTruncate(price, 5);
-
-  if (price === "0") {
-    throw new RangeError("Price is too small and was truncated to 0");
+  // Integers are exempt from the 5-sig-fig cap.
+  if (!result.isInteger()) {
+    result = result.toSignificantDigits(5);
   }
 
-  return price;
+  if (result.isZero()) {
+    throw new FormatError("Price is too small and was truncated to 0");
+  }
+
+  return result.toFixed();
 }
 
 /**
@@ -47,151 +101,25 @@ export function formatPrice(price: string | number, szDecimals: number, type: "p
  * @param szDecimals The size decimals of the asset.
  * @return Formatted size string
  *
- * @throws {TypeError} If size is not a valid number string
- * @throws {RangeError} If the formatted size is 0
+ * @throws {FormatError} If the size is not a valid finite number, or is truncated to 0.
  *
  * @example
  * ```ts
  * import { formatSize } from "@nktkas/hyperliquid/utils";
  *
- * const size = formatSize("1.23456789", 5); // → "1.23456"
+ * formatSize("1.23456789", 5); // → "1.23456"
+ * formatSize("0.123456789", 2); // → "0.12"
+ * formatSize("100", 0); // → "100"
  * ```
  */
 export function formatSize(size: string | number, szDecimals: number): string {
-  size = size.toString().trim();
-  assertNumberString(size);
+  const d = toDecimal(size, "size");
 
-  // Apply decimal limit: szDecimals
-  size = StringMath.toFixedTruncate(size, szDecimals);
+  const result = d.toDecimalPlaces(szDecimals);
 
-  if (size === "0") {
-    throw new RangeError("Size is too small and was truncated to 0");
+  if (result.isZero()) {
+    throw new FormatError("Size is too small and was truncated to 0");
   }
 
-  return size;
-}
-
-/** String-based Math operations for arbitrary precision. */
-const StringMath = {
-  /** Floor log10 (magnitude): position of most significant digit. */
-  log10Floor(value: string): number {
-    const abs = value[0] === "-" ? value.slice(1) : value;
-
-    // Check if zero or invalid
-    const num = Number(abs);
-    if (num === 0 || isNaN(num)) return -Infinity;
-
-    const [int, dec] = abs.split(".");
-
-    // Number >= 1: magnitude = length of integer part - 1
-    if (Number(int) !== 0) {
-      const trimmed = int.replace(/^0+/, "");
-      return trimmed.length - 1;
-    }
-
-    // Number < 1: count leading zeros in decimal part
-    const leadingZeros = dec.match(/^0*/)?.[0].length ?? 0;
-    return -(leadingZeros + 1);
-  },
-
-  /** Multiply by 10^exp: shift decimal point left (negative) or right (positive). */
-  multiplyByPow10(value: string, exp: number): string {
-    if (!Number.isInteger(exp)) throw new RangeError("Exponent must be an integer");
-    if (exp === 0) return formatDecimalString(value);
-
-    const neg = value[0] === "-";
-    const abs = neg ? value.slice(1) : value;
-    const [intRaw, dec = ""] = abs.split(".");
-    // Normalize empty integer part to "0" (handles ".5" → "0.5")
-    const int = intRaw || "0";
-
-    let result: string;
-
-    if (exp > 0) {
-      // Shift right: move digits from decimal to integer
-      if (exp >= dec.length) {
-        result = int + dec + "0".repeat(exp - dec.length);
-      } else {
-        result = int + dec.slice(0, exp) + "." + dec.slice(exp);
-      }
-    } else {
-      // Shift left: move digits from integer to decimal
-      const absExp = -exp;
-      if (absExp >= int.length) {
-        result = "0." + "0".repeat(absExp - int.length) + int + dec;
-      } else {
-        result = int.slice(0, -absExp) + "." + int.slice(-absExp) + dec;
-      }
-    }
-
-    return formatDecimalString((neg ? "-" : "") + result);
-  },
-
-  /** Returns the integer part of a number by removing any fractional digits. */
-  trunc(value: string): string {
-    const dotIndex = value.indexOf(".");
-    return dotIndex === -1 ? value : value.slice(0, dotIndex) || "0";
-  },
-
-  /** Truncate to a certain number of significant figures. */
-  toPrecisionTruncate(value: string, precision: number): string {
-    if (!Number.isInteger(precision)) throw new RangeError("Precision must be an integer");
-    if (precision < 1) throw new RangeError("Precision must be positive");
-    if (/^-?0+(\.0*)?$/.test(value)) return "0"; // zero is special case (don't work with log10)
-
-    const neg = value[0] === "-";
-    const abs = neg ? value.slice(1) : value;
-
-    // Calculate how much to shift: align most significant digit to ones place + (maxSigFigs-1)
-    const magnitude = StringMath.log10Floor(abs);
-    const shiftAmount = precision - magnitude - 1;
-
-    // Shift right, truncate integer part, shift back
-    const shifted = StringMath.multiplyByPow10(abs, shiftAmount);
-    const truncated = StringMath.trunc(shifted);
-    const result = StringMath.multiplyByPow10(truncated, -shiftAmount);
-
-    // Build final result and trim zeros
-    return formatDecimalString(neg ? "-" + result : result);
-  },
-
-  /** Truncate to a certain number of decimal places. */
-  toFixedTruncate(value: string, decimals: number): string {
-    if (!Number.isInteger(decimals)) throw new RangeError("Decimals must be an integer");
-    if (decimals < 0) throw new RangeError("Decimals must be non-negative");
-
-    // Match number with up to `decimals` decimal places
-    const regex = new RegExp(`^-?(?:\\d+)?(?:\\.\\d{0,${decimals}})?`);
-    const result = value.match(regex)?.[0];
-
-    if (!result) {
-      throw new TypeError("Invalid number format");
-    }
-
-    // Trim zeros after truncation
-    return formatDecimalString(result);
-  },
-};
-
-/** Normalize a decimal string by trimming unnecessary zeros and formatting edge cases. */
-export function formatDecimalString(value: string): string {
-  return value
-    // remove leading/trailing whitespace
-    .trim() // "  123.45  " → "123.45"
-    // remove leading zeros
-    .replace(/^(-?)0+(?=\d)/, "$1") // "00123" → "123", "-00.5" → "-0.5"
-    // remove trailing zeros
-    .replace(/\.0*$|(\.\d+?)0+$/, "$1") // "1.2000" → "1.2", "5.0" → "5"
-    // add leading zero if starts with decimal point
-    .replace(/^(-?)\./, "$10.") // ".5" → "0.5", "-.5" → "-0.5"
-    // add "0" if string is empty after trimming
-    .replace(/^-?$/, "0") // "" → "0", "-" → "0"
-    // normalize negative zero
-    .replace(/^-0$/, "0"); // "-0" → "0"
-}
-
-function assertNumberString(value: string): void {
-  if (!/^-?(\d+\.?\d*|\.\d+)$/.test(value)) {
-    throw new TypeError("Invalid number format");
-  }
+  return result.toFixed();
 }

--- a/src/utils/mod.ts
+++ b/src/utils/mod.ts
@@ -2,7 +2,7 @@
  * Utility helpers for working with Hyperliquid.
  *
  * This module re-exports utilities for:
- * - Formatting prices and sizes according to Hyperliquid's {@link https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/tick-and-lot-size | tick and lot size rules} ({@link formatPrice}, {@link formatSize}).
+ * - Formatting prices and sizes according to Hyperliquid's {@link https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/tick-and-lot-size | tick and lot size rules}.
  * - Converting human-readable asset symbols to Hyperliquid asset IDs ({@link SymbolConverter}).
  *
  * @example Formatting values for an order
@@ -24,4 +24,4 @@
  */
 
 export * from "./_symbolConverter.ts";
-export { formatPrice, formatSize } from "./_format.ts";
+export * from "./_format.ts";

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-import-prefix
 
 import { assertEquals, assertThrows } from "jsr:@std/assert@1";
-import { formatPrice, formatSize } from "@nktkas/hyperliquid/utils";
+import { FormatError, formatPrice, formatSize } from "@nktkas/hyperliquid/utils";
 
 // ============================================================
 // Test Data
@@ -61,8 +61,8 @@ Deno.test("formatPrice", async (t) => {
   });
 
   await t.step("edge cases", async (t) => {
-    await t.step("zero throws RangeError", () => {
-      assertThrows(() => formatPrice("0.0000001", 0), RangeError);
+    await t.step("zero throws FormatError", () => {
+      assertThrows(() => formatPrice("0.0000001", 0), FormatError);
     });
 
     await t.step("negative numbers supported", () => {
@@ -71,12 +71,10 @@ Deno.test("formatPrice", async (t) => {
   });
 
   await t.step("invalid input throws", () => {
-    assertThrows(() => formatPrice("0x1A", 0), TypeError);
-    assertThrows(() => formatPrice("1.23e5", 0), TypeError);
-    assertThrows(() => formatPrice("abc", 0), TypeError);
-    assertThrows(() => formatPrice(".", 0), TypeError);
-    assertThrows(() => formatPrice("-.", 0), TypeError);
-    assertThrows(() => formatPrice("", 0), TypeError);
+    assertThrows(() => formatPrice("abc", 0), FormatError);
+    assertThrows(() => formatPrice(".", 0), FormatError);
+    assertThrows(() => formatPrice("-.", 0), FormatError);
+    assertThrows(() => formatPrice("", 0), FormatError);
   });
 
   await t.step("reference validation", async (t) => {
@@ -114,8 +112,8 @@ Deno.test("formatSize", async (t) => {
   });
 
   await t.step("edge cases", async (t) => {
-    await t.step("zero throws RangeError", () => {
-      assertThrows(() => formatSize("0.0000001", 0), RangeError);
+    await t.step("zero throws FormatError", () => {
+      assertThrows(() => formatSize("0.0000001", 0), FormatError);
     });
 
     await t.step("negative numbers supported", () => {
@@ -124,12 +122,10 @@ Deno.test("formatSize", async (t) => {
   });
 
   await t.step("invalid input throws", () => {
-    assertThrows(() => formatSize("0xFF", 0), TypeError);
-    assertThrows(() => formatSize("5e-3", 0), TypeError);
-    assertThrows(() => formatSize("invalid", 0), TypeError);
-    assertThrows(() => formatSize(".", 0), TypeError);
-    assertThrows(() => formatSize("-.", 0), TypeError);
-    assertThrows(() => formatSize("", 0), TypeError);
+    assertThrows(() => formatSize("invalid", 0), FormatError);
+    assertThrows(() => formatSize(".", 0), FormatError);
+    assertThrows(() => formatSize("-.", 0), FormatError);
+    assertThrows(() => formatSize("", 0), FormatError);
   });
 
   await t.step("reference validation", async (t) => {


### PR DESCRIPTION
Reworks price and size formatting on [`decimal.js`](https://github.com/MikeMcl/decimal.js/) and unifies the thrown errors under `FormatError`.

## Breaking changes

- `formatPrice`/`formatSize` throw `FormatError` instead of `TypeError`/`RangeError`.

## New

- [`decimal.js`](https://github.com/MikeMcl/decimal.js/) is now a runtime dependency, confined to the `@nktkas/hyperliquid/utils` entry.

## Fixes

- Integer prices written with a trailing decimal zero are no longer mispriced: `formatPrice("100001.0", 0)` → `"100001"` (was: `"100000"`).
- Large decimal prices keep full precision: `formatPrice("1234567890123456789.0000000001", 0)` → `"1234567890123456789"` (was: `"1234500000000000000"`).
- `number` inputs that stringify to exponential notation now format: `formatPrice(1e-7, 0, "spot")` → `"0.0000001"` (was: `TypeError`).
- The `Decimal`/`UnsignedDecimal` schemas drop a ReDoS in decimal-string normalization.

---

**Type of change**

- [x] Bug fix
- [x] New API method / feature
- [ ] Schema/type update to match the Hyperliquid API
- [x] Breaking change
