### PR TITLE
feat(exchange): support always_place (a) on modify / batchModify

### DIFF
--- a/src/api/exchange/_methods/batchModify.ts
+++ b/src/api/exchange/_methods/batchModify.ts
@@ -72,6 +72,13 @@ export const BatchModifyRequest = /* @__PURE__ */ (() => {
           }),
         }),
       ),
+      /**
+       * Always place the resulting orders, even if the cancels did not succeed.
+       *
+       * When `false`, each new order must be a non-trigger order with TIF `Alo`, or a non-executable order with TIF
+       * `Gtc`. Must be omitted when `false` (actions hashed with `a: false` are rejected).
+       */
+      a: v.optional(v.boolean()),
     }),
     /** Nonce (timestamp in ms) used to prevent replay attacks. */
     nonce: UnsignedInteger,

--- a/src/api/exchange/_methods/batchModify.ts
+++ b/src/api/exchange/_methods/batchModify.ts
@@ -75,10 +75,10 @@ export const BatchModifyRequest = /* @__PURE__ */ (() => {
       /**
        * Always place the resulting orders, even if the cancels did not succeed.
        *
-       * When `false`, each new order must be a non-trigger order with TIF `Alo`, or a non-executable order with TIF
-       * `Gtc`. Must be omitted when `false` (actions hashed with `a: false` are rejected).
+       * Omit the field otherwise; the default behavior requires each new order to be a non-trigger order with TIF
+       * `Alo`, or a non-executable order with TIF `Gtc`.
        */
-      a: v.optional(v.boolean()),
+      a: v.optional(v.literal(true)),
     }),
     /** Nonce (timestamp in ms) used to prevent replay attacks. */
     nonce: UnsignedInteger,

--- a/src/api/exchange/_methods/modify.ts
+++ b/src/api/exchange/_methods/modify.ts
@@ -66,6 +66,13 @@ export const ModifyRequest = /* @__PURE__ */ (() => {
         /** Client Order ID. */
         c: v.optional(Cloid),
       }),
+      /**
+       * Always place the resulting order, even if the cancel did not succeed.
+       *
+       * When `false`, the new order must be a non-trigger order with TIF `Alo`, or a non-executable order with TIF
+       * `Gtc`. Must be omitted when `false` (actions hashed with `a: false` are rejected).
+       */
+      a: v.optional(v.boolean()),
     }),
     /** Nonce (timestamp in ms) used to prevent replay attacks. */
     nonce: UnsignedInteger,

--- a/src/api/exchange/_methods/modify.ts
+++ b/src/api/exchange/_methods/modify.ts
@@ -69,10 +69,10 @@ export const ModifyRequest = /* @__PURE__ */ (() => {
       /**
        * Always place the resulting order, even if the cancel did not succeed.
        *
-       * When `false`, the new order must be a non-trigger order with TIF `Alo`, or a non-executable order with TIF
-       * `Gtc`. Must be omitted when `false` (actions hashed with `a: false` are rejected).
+       * Omit the field otherwise; the default behavior requires the new order to be a non-trigger order with TIF
+       * `Alo`, or a non-executable order with TIF `Gtc`.
        */
-      a: v.optional(v.boolean()),
+      a: v.optional(v.literal(true)),
     }),
     /** Nonce (timestamp in ms) used to prevent replay attacks. */
     nonce: UnsignedInteger,

--- a/tests/api/exchange/batchModify.test.ts
+++ b/tests/api/exchange/batchModify.test.ts
@@ -143,7 +143,27 @@ runTest({
       return { params, result: await exchClient.batchModify(params) };
     })();
 
-    const data = [restingGtc, restingAlo, filledGtc, ioc, frontendMarket, triggerTp, triggerSl];
+    // resting | trigger | tp | always place
+    const triggerAlwaysPlace = await (async () => {
+      const order = await openOrder(exchClient, "limit");
+      const params: BatchModifyParameters = {
+        modifies: [{
+          oid: order.oid,
+          order: {
+            a: order.a,
+            b: order.b,
+            p: order.p,
+            s: order.s,
+            r: false,
+            t: { trigger: { isMarket: true, triggerPx: order.pxUp, tpsl: "tp" } },
+          },
+        }],
+        a: true,
+      };
+      return { params, result: await exchClient.batchModify(params) };
+    })();
+
+    const data = [restingGtc, restingAlo, filledGtc, ioc, frontendMarket, triggerTp, triggerSl, triggerAlwaysPlace];
 
     schemaCoverage(paramsSchema, data.map((d) => d.params));
     schemaCoverage(responseSchema, data.map((d) => d.result), [

--- a/tests/api/exchange/modify.test.ts
+++ b/tests/api/exchange/modify.test.ts
@@ -112,7 +112,25 @@ runTest({
       return { params, result: await exchClient.modify(params) };
     })();
 
-    const data = [restingGtc, restingAlo, ioc, frontendMarket, triggerTp, triggerSl];
+    // resting | trigger | tp | always place
+    const triggerAlwaysPlace = await (async () => {
+      const order = await openOrder(exchClient, "limit");
+      const params: ModifyParameters = {
+        oid: order.oid,
+        order: {
+          a: order.a,
+          b: order.b,
+          p: order.p,
+          s: order.s,
+          r: false,
+          t: { trigger: { isMarket: true, triggerPx: order.pxUp, tpsl: "tp" } },
+        },
+        a: true,
+      };
+      return { params, result: await exchClient.modify(params) };
+    })();
+
+    const data = [restingGtc, restingAlo, ioc, frontendMarket, triggerTp, triggerSl, triggerAlwaysPlace];
 
     schemaCoverage(paramsSchema, data.map((d) => d.params));
     schemaCoverage(responseSchema, data.map((d) => d.result));


### PR DESCRIPTION
### Summary

Adds the optional action-level `a` (`always_place`) boolean to the `modify` and `batchModify` action schemas, per the Hyperliquid [exchange-endpoint docs](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint).

### Why

Hyperliquid added `always_place` to `modify`/`batchModify` (announced in the HL API channel, messages 325 + 327). Per the docs:

- `a: true` places the resulting order even if the cancel did not succeed.
- `a: false` requires the new order to be non-trigger with TIF `Alo`, or a non-executable `Gtc` order, and **must be omitted when false** — *"actions hashed with `a: false` will be rejected."*

Once HL enforces the new semantics, a `modify` that targets a **trigger order** (TP/SL) is rejected unless the action carries `a: true`. Today the SDK has no way to send it: the field isn't in the schema, so `canonicalize` throws `Key "a" exists in data but not in schema` (and it's part of the signed L1 action, so it can't be injected after signing).

### What

- Add `a: v.optional(v.boolean())` as the **last** entry of the `modify` and `batchModify` action objects, so `canonicalize` orders it to match HL's documented wire layout `{ type, oid, order, a }` / `{ type, batchModify… modifies, a }`. Making it `v.optional` (and never serializing `false`) preserves the omit-when-false rule, since absent optionals are dropped before hashing.
- Add JSDoc describing the semantics and the omit-when-false constraint.
- Add an always-place sample to `modify`/`batchModify` tests so `schemaCoverage` exercises the new optional field.

### Testing

`deno task check` passes (fmt, lint incl. the valibot plugins, type check, jsdoc-sync, export-sync). The live-API test cases require a funded testnet key (per CONTRIBUTING), so I couldn't run the network portion locally — the added samples set `a: true` on a trigger modify and should exercise the new path under your CI.

### Reference

- HL exchange-endpoint docs — "Modify an order" / "Modify multiple orders": https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
- HL API announcement: https://t.me/hyperliquid_api/327