### PR TITLE
feat(exchange): add optional fast flag (f) to cancel / cancelByCloid

### DIFF
--- a/src/api/exchange/_methods/cancel.ts
+++ b/src/api/exchange/_methods/cancel.ts
@@ -25,6 +25,8 @@ export const CancelRequest = /* @__PURE__ */ (() => {
           o: UnsignedInteger,
         }),
       ),
+      /** Prioritize this cancel in the mempool (fast cancel). */
+      f: v.optional(v.literal(true)),
     }),
     /** Nonce (timestamp in ms) used to prevent replay attacks. */
     nonce: UnsignedInteger,

--- a/src/api/exchange/_methods/cancelByCloid.ts
+++ b/src/api/exchange/_methods/cancelByCloid.ts
@@ -26,6 +26,8 @@ export const CancelByCloidRequest = /* @__PURE__ */ (() => {
           cloid: Cloid,
         }),
       ),
+      /** Prioritize this cancel in the mempool (fast cancel). */
+      f: v.optional(v.literal(true)),
     }),
     /** Nonce (timestamp in ms) used to prevent replay attacks. */
     nonce: UnsignedInteger,

--- a/tests/api/exchange/cancel.test.ts
+++ b/tests/api/exchange/cancel.test.ts
@@ -12,13 +12,21 @@ const paramsSchema = valibotToJsonSchema(v.omit(v.object(CancelRequest.entries.a
 runTest({
   name: "cancel",
   codeTestFn: async (_t, exchClient) => {
-    const data = await Promise.all([
-      (async () => {
-        const order = await openOrder(exchClient, "limit");
-        const params: CancelParameters = { cancels: [{ a: order.a, o: order.oid }] };
-        return { params, result: await exchClient.cancel(params) };
-      })(),
-    ]);
+    // standard
+    const standard = await (async () => {
+      const order = await openOrder(exchClient, "limit");
+      const params: CancelParameters = { cancels: [{ a: order.a, o: order.oid }] };
+      return { params, result: await exchClient.cancel(params) };
+    })();
+
+    // fast
+    const fast = await (async () => {
+      const order = await openOrder(exchClient, "limit");
+      const params: CancelParameters = { cancels: [{ a: order.a, o: order.oid }], f: true };
+      return { params, result: await exchClient.cancel(params) };
+    })();
+
+    const data = [standard, fast];
 
     schemaCoverage(paramsSchema, data.map((d) => d.params));
     schemaCoverage(responseSchema, data.map((d) => d.result));

--- a/tests/api/exchange/cancelByCloid.test.ts
+++ b/tests/api/exchange/cancelByCloid.test.ts
@@ -12,13 +12,21 @@ const paramsSchema = valibotToJsonSchema(v.omit(v.object(CancelByCloidRequest.en
 runTest({
   name: "cancelByCloid",
   codeTestFn: async (_t, exchClient) => {
-    const data = await Promise.all([
-      (async () => {
-        const order = await openOrder(exchClient, "limit");
-        const params: CancelByCloidParameters = { cancels: [{ asset: order.a, cloid: order.cloid }] };
-        return { params, result: await exchClient.cancelByCloid(params) };
-      })(),
-    ]);
+    // standard
+    const standard = await (async () => {
+      const order = await openOrder(exchClient, "limit");
+      const params: CancelByCloidParameters = { cancels: [{ asset: order.a, cloid: order.cloid }] };
+      return { params, result: await exchClient.cancelByCloid(params) };
+    })();
+
+    // fast
+    const fast = await (async () => {
+      const order = await openOrder(exchClient, "limit");
+      const params: CancelByCloidParameters = { cancels: [{ asset: order.a, cloid: order.cloid }], f: true };
+      return { params, result: await exchClient.cancelByCloid(params) };
+    })();
+
+    const data = [standard, fast];
 
     schemaCoverage(paramsSchema, data.map((d) => d.params));
     schemaCoverage(responseSchema, data.map((d) => d.result));


### PR DESCRIPTION
**What & why**

Update the API schemas based on the official documentation:
https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#cancel-order-s
https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#cancel-order-s-by-cloid

**Type of change**

- [ ] Bug fix
- [x] New API method / feature
- [ ] Schema/type update to match the Hyperliquid API
- [ ] Breaking change
