### PR TITLE
refactor(subscription)!: replace the onError callback with an options object

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -248,17 +248,26 @@ const subscription = await client.allMids((data) => {
 
 ### Errors
 
-Each subscription method takes an optional `onError` callback as its last argument, invoked once if the subscription is
-dropped — a failed [resubscribe](transports.md#resubscription) or a permanently lost connection:
+Each subscription method takes an optional `options` argument — `{ signal?, onError? }`. The `onError` callback runs at
+most once, when an already confirmed subscription fails:
+
+- the server rejects a re-subscription after a [reconnect](transports.md#reconnection);
+- the connection is permanently terminated;
+- the connection goes down while [re-subscription](transports.md#resubscription) is disabled.
+
+Failures before confirmation reject the subscribe promise instead. After `onError` fires, the subscription is removed
+and no further events arrive:
 
 ```ts
 const subscription = await client.allMids(
   (data) => {
     console.log(data.mids);
   },
-  (error) => {
-    // The subscription is gone — inspect the error and re-subscribe if needed
-    console.error(error);
+  {
+    onError: (error: TransportError) => {
+      // The subscription is gone — inspect the error and re-subscribe if needed
+      console.error(error);
+    },
   },
 );
 ```

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -145,20 +145,3 @@ const transport = new WebSocketTransport({ resubscribe: false });
 
 If a subscription then fails to re-establish, its `onError` callback is invoked — handle it as shown in
 [Handle failures](#handle-failures).
-
-### Handle failures
-
-Resubscription rarely fails. When it does, or when the connection is lost for good, the `onError` callback fires once
-and that channel is dropped. It's the optional last argument of every subscription method:
-
-```ts
-await client.allMids(
-  (data) => {
-    console.log(data.mids);
-  },
-  (error: WebSocketRequestError) => {
-    console.error("Subscription error:", error);
-    // The subscription is gone — check the error and/or subscribe again
-  },
-);
-```

--- a/src/api/subscription/_methods/_base/_config.ts
+++ b/src/api/subscription/_methods/_base/_config.ts
@@ -1,12 +1,28 @@
 /**
- * Configuration types for Subscription API requests.
+ * Configuration and option types for Subscription API methods.
  * @module
  */
 
-import type { ISubscriptionTransport } from "../../../../transport/mod.ts";
+import type { ISubscriptionTransport, TransportError } from "../../../../transport/mod.ts";
 
 /** Configuration for subscription API requests. */
 export interface SubscriptionConfig<T extends ISubscriptionTransport = ISubscriptionTransport> {
   /** The transport used to connect to the Hyperliquid API. */
   transport: T;
+}
+
+/** Options for Subscription API methods. */
+export interface SubscriptionOptions {
+  /** Stops waiting for the confirmation and detaches the listener. */
+  signal?: AbortSignal;
+  /**
+   * Callback invoked at most once, when an already confirmed subscription fails:
+   * - the server rejects a re-subscription after a reconnect;
+   * - the connection is permanently terminated;
+   * - the connection goes down while re-subscription is disabled.
+   *
+   * Failures before the confirmation reject the subscribe promise instead.
+   * After the callback fires, the subscription is removed and no further events or errors follow.
+   */
+  onError?: (error: TransportError) => void;
 }

--- a/src/api/subscription/_methods/_base/mod.ts
+++ b/src/api/subscription/_methods/_base/mod.ts
@@ -3,4 +3,4 @@
  * @module
  */
 
-export type { SubscriptionConfig } from "./_config.ts";
+export type { SubscriptionConfig, SubscriptionOptions } from "./_config.ts";

--- a/src/api/subscription/_methods/activeAssetCtx.ts
+++ b/src/api/subscription/_methods/activeAssetCtx.ts
@@ -36,8 +36,8 @@ export type ActiveAssetCtxEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode activeAssetCtx} function. */
 export type ActiveAssetCtxParameters = Omit<v.InferInput<typeof ActiveAssetCtxRequest>, "type">;
@@ -48,7 +48,7 @@ export type ActiveAssetCtxParameters = Omit<v.InferInput<typeof ActiveAssetCtxRe
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -74,12 +74,12 @@ export function activeAssetCtx(
   config: SubscriptionConfig,
   params: ActiveAssetCtxParameters,
   listener: (data: ActiveAssetCtxEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(ActiveAssetCtxRequest, { type: "activeAssetCtx", ...params });
   return config.transport.subscribe<ActiveAssetCtxEvent>(payload.type, payload, (e) => {
     if (e.detail.coin === payload.coin) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/activeAssetData.ts
+++ b/src/api/subscription/_methods/activeAssetData.ts
@@ -34,8 +34,8 @@ export type ActiveAssetDataEvent = ActiveAssetDataResponse;
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode activeAssetData} function. */
 export type ActiveAssetDataParameters = Omit<v.InferInput<typeof ActiveAssetDataRequest>, "type">;
@@ -46,7 +46,7 @@ export type ActiveAssetDataParameters = Omit<v.InferInput<typeof ActiveAssetData
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -72,12 +72,12 @@ export function activeAssetData(
   config: SubscriptionConfig,
   params: ActiveAssetDataParameters,
   listener: (data: ActiveAssetDataEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(ActiveAssetDataRequest, { type: "activeAssetData", ...params });
   return config.transport.subscribe<ActiveAssetDataEvent>(payload.type, payload, (e) => {
     if (e.detail.coin === payload.coin && e.detail.user === payload.user) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/activeSpotAssetCtx.ts
+++ b/src/api/subscription/_methods/activeSpotAssetCtx.ts
@@ -36,8 +36,8 @@ export type ActiveSpotAssetCtxEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode activeSpotAssetCtx} function. */
 export type ActiveSpotAssetCtxParameters = Omit<v.InferInput<typeof ActiveSpotAssetCtxRequest>, "type">;
@@ -48,7 +48,7 @@ export type ActiveSpotAssetCtxParameters = Omit<v.InferInput<typeof ActiveSpotAs
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -74,12 +74,12 @@ export function activeSpotAssetCtx(
   config: SubscriptionConfig,
   params: ActiveSpotAssetCtxParameters,
   listener: (data: ActiveSpotAssetCtxEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(ActiveSpotAssetCtxRequest, { type: "activeAssetCtx", ...params });
   return config.transport.subscribe<ActiveSpotAssetCtxEvent>("activeSpotAssetCtx", payload, (e) => {
     if (e.detail.coin === payload.coin) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/allDexsAssetCtxs.ts
+++ b/src/api/subscription/_methods/allDexsAssetCtxs.ts
@@ -37,15 +37,15 @@ export type AllDexsAssetCtxsEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /**
  * Subscribe to asset contexts for all DEXs.
  *
  * @param config General configuration for Subscription API subscriptions.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -69,12 +69,12 @@ import type { SubscriptionConfig } from "./_base/mod.ts";
 export function allDexsAssetCtxs(
   config: SubscriptionConfig,
   listener: (data: AllDexsAssetCtxsEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(AllDexsAssetCtxsRequest, {
     type: "allDexsAssetCtxs",
   });
   return config.transport.subscribe<AllDexsAssetCtxsEvent>(payload.type, payload, (e) => {
     listener(e.detail);
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/allDexsClearinghouseState.ts
+++ b/src/api/subscription/_methods/allDexsClearinghouseState.ts
@@ -45,8 +45,8 @@ export type AllDexsClearinghouseStateEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode allDexsClearinghouseState} function. */
 export type AllDexsClearinghouseStateParameters = Omit<v.InferInput<typeof AllDexsClearinghouseStateRequest>, "type">;
@@ -57,7 +57,7 @@ export type AllDexsClearinghouseStateParameters = Omit<v.InferInput<typeof AllDe
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -83,7 +83,7 @@ export function allDexsClearinghouseState(
   config: SubscriptionConfig,
   params: AllDexsClearinghouseStateParameters,
   listener: (data: AllDexsClearinghouseStateEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(AllDexsClearinghouseStateRequest, {
     type: "allDexsClearinghouseState",
@@ -93,5 +93,5 @@ export function allDexsClearinghouseState(
     if (e.detail.user === payload.user) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/allMids.ts
+++ b/src/api/subscription/_methods/allMids.ts
@@ -36,8 +36,8 @@ export type AllMidsEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode allMids} function. */
 export type AllMidsParameters = Omit<v.InferInput<typeof AllMidsRequest>, "type">;
@@ -48,7 +48,7 @@ export type AllMidsParameters = Omit<v.InferInput<typeof AllMidsRequest>, "type"
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -72,27 +72,24 @@ export type AllMidsParameters = Omit<v.InferInput<typeof AllMidsRequest>, "type"
 export function allMids(
   config: SubscriptionConfig,
   listener: (data: AllMidsEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription>;
 export function allMids(
   config: SubscriptionConfig,
   params: AllMidsParameters,
   listener: (data: AllMidsEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription>;
 export function allMids(
   config: SubscriptionConfig,
   paramsOrListener: AllMidsParameters | ((data: AllMidsEvent) => void),
-  listenerOrOnError?: ((data: AllMidsEvent) => void) | ((error: TransportError) => void),
-  maybeOnError?: (error: TransportError) => void,
+  listenerOrOptions?: ((data: AllMidsEvent) => void) | SubscriptionOptions,
+  maybeOptions?: SubscriptionOptions,
 ): Promise<ISubscription> {
-  const params = typeof paramsOrListener === "function" ? {} : paramsOrListener;
-  const listener = (typeof paramsOrListener === "function" ? paramsOrListener : listenerOrOnError) as (
-    data: AllMidsEvent,
-  ) => void;
-  const onError = (typeof paramsOrListener === "function" ? listenerOrOnError : maybeOnError) as
-    | ((error: TransportError) => void)
-    | undefined;
+  const isListenerFirst = typeof paramsOrListener === "function";
+  const params = isListenerFirst ? {} : paramsOrListener;
+  const listener = isListenerFirst ? paramsOrListener : listenerOrOptions as (data: AllMidsEvent) => void;
+  const options = isListenerFirst ? listenerOrOptions as SubscriptionOptions | undefined : maybeOptions;
 
   const payload = parse(AllMidsRequest, {
     type: "allMids",
@@ -103,5 +100,5 @@ export function allMids(
     if (e.detail.dex === payload.dex) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/assetCtxs.ts
+++ b/src/api/subscription/_methods/assetCtxs.ts
@@ -36,8 +36,8 @@ export type AssetCtxsEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode assetCtxs} function. */
 export type AssetCtxsParameters = Omit<v.InferInput<typeof AssetCtxsRequest>, "type">;
@@ -48,7 +48,7 @@ export type AssetCtxsParameters = Omit<v.InferInput<typeof AssetCtxsRequest>, "t
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -72,36 +72,33 @@ export type AssetCtxsParameters = Omit<v.InferInput<typeof AssetCtxsRequest>, "t
 export function assetCtxs(
   config: SubscriptionConfig,
   listener: (data: AssetCtxsEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription>;
 export function assetCtxs(
   config: SubscriptionConfig,
   params: AssetCtxsParameters,
   listener: (data: AssetCtxsEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription>;
 export function assetCtxs(
   config: SubscriptionConfig,
   paramsOrListener: AssetCtxsParameters | ((data: AssetCtxsEvent) => void),
-  listenerOrOnError?: ((data: AssetCtxsEvent) => void) | ((error: TransportError) => void),
-  maybeOnError?: (error: TransportError) => void,
+  listenerOrOptions?: ((data: AssetCtxsEvent) => void) | SubscriptionOptions,
+  maybeOptions?: SubscriptionOptions,
 ): Promise<ISubscription> {
-  const params = typeof paramsOrListener === "function" ? {} : paramsOrListener;
-  const listener = (typeof paramsOrListener === "function" ? paramsOrListener : listenerOrOnError) as (
-    data: AssetCtxsEvent,
-  ) => void;
-  const onError = (typeof paramsOrListener === "function" ? listenerOrOnError : maybeOnError) as
-    | ((error: TransportError) => void)
-    | undefined;
+  const isListenerFirst = typeof paramsOrListener === "function";
+  const params = isListenerFirst ? {} : paramsOrListener;
+  const listener = isListenerFirst ? paramsOrListener : listenerOrOptions as (data: AssetCtxsEvent) => void;
+  const options = isListenerFirst ? listenerOrOptions as SubscriptionOptions | undefined : maybeOptions;
 
   const payload = parse(AssetCtxsRequest, {
     type: "assetCtxs",
     ...params,
-    dex: params.dex ?? "", // Same value as in response
+    dex: params.dex ?? "", // same value as in response
   });
   return config.transport.subscribe<AssetCtxsEvent>(payload.type, payload, (e) => {
     if (e.detail.dex === payload.dex) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/bbo.ts
+++ b/src/api/subscription/_methods/bbo.ts
@@ -67,8 +67,8 @@ export type BboEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode bbo} function. */
 export type BboParameters = Omit<v.InferInput<typeof BboRequest>, "type">;
@@ -79,7 +79,7 @@ export type BboParameters = Omit<v.InferInput<typeof BboRequest>, "type">;
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -105,12 +105,12 @@ export function bbo(
   config: SubscriptionConfig,
   params: BboParameters,
   listener: (data: BboEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(BboRequest, { type: "bbo", ...params });
   return config.transport.subscribe<BboEvent>(payload.type, payload, (e) => {
     if (e.detail.coin === payload.coin) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/candle.ts
+++ b/src/api/subscription/_methods/candle.ts
@@ -67,8 +67,8 @@ export type CandleEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode candle} function. */
 export type CandleParameters = Omit<v.InferInput<typeof CandleRequest>, "type">;
@@ -79,7 +79,7 @@ export type CandleParameters = Omit<v.InferInput<typeof CandleRequest>, "type">;
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -105,12 +105,12 @@ export function candle(
   config: SubscriptionConfig,
   params: CandleParameters,
   listener: (data: CandleEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(CandleRequest, { type: "candle", ...params });
   return config.transport.subscribe<CandleEvent>(payload.type, payload, (e) => {
     if (e.detail.s === payload.coin && e.detail.i === payload.interval) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/clearinghouseState.ts
+++ b/src/api/subscription/_methods/clearinghouseState.ts
@@ -44,8 +44,8 @@ export type ClearinghouseStateEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode clearinghouseState} function. */
 export type ClearinghouseStateParameters = Omit<v.InferInput<typeof ClearinghouseStateRequest>, "type">;
@@ -56,7 +56,7 @@ export type ClearinghouseStateParameters = Omit<v.InferInput<typeof Clearinghous
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -82,7 +82,7 @@ export function clearinghouseState(
   config: SubscriptionConfig,
   params: ClearinghouseStateParameters,
   listener: (data: ClearinghouseStateEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(ClearinghouseStateRequest, {
     type: "clearinghouseState",
@@ -93,5 +93,5 @@ export function clearinghouseState(
     if (e.detail.user === payload.user && e.detail.dex === payload.dex) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/fastAssetCtxs.ts
+++ b/src/api/subscription/_methods/fastAssetCtxs.ts
@@ -43,8 +43,8 @@ export type FastAssetCtxsEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /**
  * Subscribe to mark and mid prices for all assets.
@@ -54,7 +54,7 @@ import type { SubscriptionConfig } from "./_base/mod.ts";
  *
  * @param config General configuration for Subscription API subscriptions.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -78,7 +78,7 @@ import type { SubscriptionConfig } from "./_base/mod.ts";
 export function fastAssetCtxs(
   config: SubscriptionConfig,
   listener: (data: FastAssetCtxsEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(FastAssetCtxsRequest, { type: "fastAssetCtxs" });
   // The server pushes each update as a base64 + raw DEFLATE (RFC 1951) compressed JSON string (assumed to be valid).
@@ -86,7 +86,7 @@ export function fastAssetCtxs(
   let queue = Promise.resolve();
   return config.transport.subscribe<string>(payload.type, payload, (e) => {
     queue = queue.then(async () => listener(await decompress(e.detail)));
-  }, { onError });
+  }, options);
 }
 
 /** Decode a base64 + raw DEFLATE (RFC 1951) payload into a {@linkcode FastAssetCtxsEvent}. */

--- a/src/api/subscription/_methods/l2Book.ts
+++ b/src/api/subscription/_methods/l2Book.ts
@@ -73,8 +73,8 @@ export type L2BookEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode l2Book} function. */
 export type L2BookParameters = Omit<v.InferInput<typeof L2BookRequest>, "type">;
@@ -85,7 +85,7 @@ export type L2BookParameters = Omit<v.InferInput<typeof L2BookRequest>, "type">;
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -111,7 +111,7 @@ export function l2Book(
   config: SubscriptionConfig,
   params: L2BookParameters,
   listener: (data: L2BookEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(L2BookRequest, {
     type: "l2Book",
@@ -123,5 +123,5 @@ export function l2Book(
     if (e.detail.coin === payload.coin) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/notification.ts
+++ b/src/api/subscription/_methods/notification.ts
@@ -34,8 +34,8 @@ export type NotificationEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode notification} function. */
 export type NotificationParameters = Omit<v.InferInput<typeof NotificationRequest>, "type">;
@@ -46,7 +46,7 @@ export type NotificationParameters = Omit<v.InferInput<typeof NotificationReques
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -72,10 +72,10 @@ export function notification(
   config: SubscriptionConfig,
   params: NotificationParameters,
   listener: (data: NotificationEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(NotificationRequest, { type: "notification", ...params });
   return config.transport.subscribe<NotificationEvent>(payload.type, payload, (e) => {
     listener(e.detail);
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/openOrders.ts
+++ b/src/api/subscription/_methods/openOrders.ts
@@ -44,8 +44,8 @@ export type OpenOrdersEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode openOrders} function. */
 export type OpenOrdersParameters = Omit<v.InferInput<typeof OpenOrdersRequest>, "type">;
@@ -56,7 +56,7 @@ export type OpenOrdersParameters = Omit<v.InferInput<typeof OpenOrdersRequest>, 
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -82,7 +82,7 @@ export function openOrders(
   config: SubscriptionConfig,
   params: OpenOrdersParameters,
   listener: (data: OpenOrdersEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(OpenOrdersRequest, {
     type: "openOrders",
@@ -93,5 +93,5 @@ export function openOrders(
     if (e.detail.user === payload.user && e.detail.dex === payload.dex) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/orderUpdates.ts
+++ b/src/api/subscription/_methods/orderUpdates.ts
@@ -70,8 +70,8 @@ export type OrderUpdatesEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode orderUpdates} function. */
 export type OrderUpdatesParameters = Omit<v.InferInput<typeof OrderUpdatesRequest>, "type">;
@@ -82,7 +82,7 @@ export type OrderUpdatesParameters = Omit<v.InferInput<typeof OrderUpdatesReques
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -108,10 +108,10 @@ export function orderUpdates(
   config: SubscriptionConfig,
   params: OrderUpdatesParameters,
   listener: (data: OrderUpdatesEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(OrderUpdatesRequest, { type: "orderUpdates", ...params });
   return config.transport.subscribe<OrderUpdatesEvent>(payload.type, payload, (e) => {
     listener(e.detail);
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/outcomeMetaUpdates.ts
+++ b/src/api/subscription/_methods/outcomeMetaUpdates.ts
@@ -80,15 +80,15 @@ export type OutcomeMetaUpdatesEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /**
  * Subscribe to prediction market outcome/question metadata updates.
  *
  * @param config General configuration for Subscription API subscriptions.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -112,10 +112,10 @@ import type { SubscriptionConfig } from "./_base/mod.ts";
 export function outcomeMetaUpdates(
   config: SubscriptionConfig,
   listener: (data: OutcomeMetaUpdatesEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(OutcomeMetaUpdatesRequest, { type: "outcomeMetaUpdates" });
   return config.transport.subscribe<OutcomeMetaUpdatesEvent>(payload.type, payload, (e) => {
     listener(e.detail);
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/spotAssetCtxs.ts
+++ b/src/api/subscription/_methods/spotAssetCtxs.ts
@@ -29,15 +29,15 @@ export type SpotAssetCtxsEvent = SpotAssetCtx[];
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /**
  * Subscribe to context updates for all spot assets.
  *
  * @param config General configuration for Subscription API subscriptions.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -61,10 +61,10 @@ import type { SubscriptionConfig } from "./_base/mod.ts";
 export function spotAssetCtxs(
   config: SubscriptionConfig,
   listener: (data: SpotAssetCtxsEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(SpotAssetCtxsRequest, { type: "spotAssetCtxs" });
   return config.transport.subscribe<SpotAssetCtxsEvent>(payload.type, payload, (e) => {
     listener(e.detail);
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/spotState.ts
+++ b/src/api/subscription/_methods/spotState.ts
@@ -42,8 +42,8 @@ export type SpotStateEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode spotState} function. */
 export type SpotStateParameters = Omit<v.InferInput<typeof SpotStateRequest>, "type">;
@@ -54,7 +54,7 @@ export type SpotStateParameters = Omit<v.InferInput<typeof SpotStateRequest>, "t
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -80,12 +80,12 @@ export function spotState(
   config: SubscriptionConfig,
   params: SpotStateParameters,
   listener: (data: SpotStateEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(SpotStateRequest, { type: "spotState", ...params });
   return config.transport.subscribe<SpotStateEvent>(payload.type, payload, (e) => {
     if (e.detail.user === payload.user) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/trades.ts
+++ b/src/api/subscription/_methods/trades.ts
@@ -31,8 +31,8 @@ export type TradesEvent = RecentTradesResponse;
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode trades} function. */
 export type TradesParameters = Omit<v.InferInput<typeof TradesRequest>, "type">;
@@ -43,7 +43,7 @@ export type TradesParameters = Omit<v.InferInput<typeof TradesRequest>, "type">;
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -69,12 +69,12 @@ export function trades(
   config: SubscriptionConfig,
   params: TradesParameters,
   listener: (data: TradesEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(TradesRequest, { type: "trades", ...params });
   return config.transport.subscribe<TradesEvent>(payload.type, payload, (e) => {
     if (e.detail[0]?.coin === payload.coin) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/twapStates.ts
+++ b/src/api/subscription/_methods/twapStates.ts
@@ -49,8 +49,8 @@ export type TwapStatesEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode twapStates} function. */
 export type TwapStatesParameters = Omit<v.InferInput<typeof TwapStatesRequest>, "type">;
@@ -61,7 +61,7 @@ export type TwapStatesParameters = Omit<v.InferInput<typeof TwapStatesRequest>, 
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -87,7 +87,7 @@ export function twapStates(
   config: SubscriptionConfig,
   params: TwapStatesParameters,
   listener: (data: TwapStatesEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(TwapStatesRequest, {
     type: "twapStates",
@@ -98,5 +98,5 @@ export function twapStates(
     if (e.detail.user === payload.user && e.detail.dex === payload.dex) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/userEvents.ts
+++ b/src/api/subscription/_methods/userEvents.ts
@@ -106,8 +106,8 @@ export type UserEventsEvent =
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode userEvents} function. */
 export type UserEventsParameters = Omit<v.InferInput<typeof UserEventsRequest>, "type">;
@@ -118,7 +118,7 @@ export type UserEventsParameters = Omit<v.InferInput<typeof UserEventsRequest>, 
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -144,10 +144,10 @@ export function userEvents(
   config: SubscriptionConfig,
   params: UserEventsParameters,
   listener: (data: UserEventsEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(UserEventsRequest, { type: "userEvents", ...params });
   return config.transport.subscribe<UserEventsEvent>("user", payload, (e) => {
     listener(e.detail);
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/userFills.ts
+++ b/src/api/subscription/_methods/userFills.ts
@@ -44,8 +44,8 @@ export type UserFillsEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode userFills} function. */
 export type UserFillsParameters = Omit<v.InferInput<typeof UserFillsRequest>, "type">;
@@ -56,7 +56,7 @@ export type UserFillsParameters = Omit<v.InferInput<typeof UserFillsRequest>, "t
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -82,7 +82,7 @@ export function userFills(
   config: SubscriptionConfig,
   params: UserFillsParameters,
   listener: (data: UserFillsEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(UserFillsRequest, {
     type: "userFills",
@@ -93,5 +93,5 @@ export function userFills(
     if (e.detail.user === payload.user) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/userFundings.ts
+++ b/src/api/subscription/_methods/userFundings.ts
@@ -63,8 +63,8 @@ export type UserFundingsEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode userFundings} function. */
 export type UserFundingsParameters = Omit<v.InferInput<typeof UserFundingsRequest>, "type">;
@@ -75,7 +75,7 @@ export type UserFundingsParameters = Omit<v.InferInput<typeof UserFundingsReques
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -101,12 +101,12 @@ export function userFundings(
   config: SubscriptionConfig,
   params: UserFundingsParameters,
   listener: (data: UserFundingsEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(UserFundingsRequest, { type: "userFundings", ...params });
   return config.transport.subscribe<UserFundingsEvent>(payload.type, payload, (e) => {
     if (e.detail.user === payload.user) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/userHistoricalOrders.ts
+++ b/src/api/subscription/_methods/userHistoricalOrders.ts
@@ -42,8 +42,8 @@ export type UserHistoricalOrdersEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode userHistoricalOrders} function. */
 export type UserHistoricalOrdersParameters = Omit<v.InferInput<typeof UserHistoricalOrdersRequest>, "type">;
@@ -54,7 +54,7 @@ export type UserHistoricalOrdersParameters = Omit<v.InferInput<typeof UserHistor
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -80,12 +80,12 @@ export function userHistoricalOrders(
   config: SubscriptionConfig,
   params: UserHistoricalOrdersParameters,
   listener: (data: UserHistoricalOrdersEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(UserHistoricalOrdersRequest, { type: "userHistoricalOrders", ...params });
   return config.transport.subscribe<UserHistoricalOrdersEvent>(payload.type, payload, (e) => {
     if (e.detail.user === payload.user) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/userNonFundingLedgerUpdates.ts
+++ b/src/api/subscription/_methods/userNonFundingLedgerUpdates.ts
@@ -42,8 +42,8 @@ export type UserNonFundingLedgerUpdatesEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode userNonFundingLedgerUpdates} function. */
 export type UserNonFundingLedgerUpdatesParameters = Omit<
@@ -57,7 +57,7 @@ export type UserNonFundingLedgerUpdatesParameters = Omit<
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -83,12 +83,12 @@ export function userNonFundingLedgerUpdates(
   config: SubscriptionConfig,
   params: UserNonFundingLedgerUpdatesParameters,
   listener: (data: UserNonFundingLedgerUpdatesEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(UserNonFundingLedgerUpdatesRequest, { type: "userNonFundingLedgerUpdates", ...params });
   return config.transport.subscribe<UserNonFundingLedgerUpdatesEvent>(payload.type, payload, (e) => {
     if (e.detail.user === payload.user) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/userTwapHistory.ts
+++ b/src/api/subscription/_methods/userTwapHistory.ts
@@ -42,8 +42,8 @@ export type UserTwapHistoryEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode userTwapHistory} function. */
 export type UserTwapHistoryParameters = Omit<v.InferInput<typeof UserTwapHistoryRequest>, "type">;
@@ -54,7 +54,7 @@ export type UserTwapHistoryParameters = Omit<v.InferInput<typeof UserTwapHistory
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -80,12 +80,12 @@ export function userTwapHistory(
   config: SubscriptionConfig,
   params: UserTwapHistoryParameters,
   listener: (data: UserTwapHistoryEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(UserTwapHistoryRequest, { type: "userTwapHistory", ...params });
   return config.transport.subscribe<UserTwapHistoryEvent>(payload.type, payload, (e) => {
     if (e.detail.user === payload.user) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/userTwapSliceFills.ts
+++ b/src/api/subscription/_methods/userTwapSliceFills.ts
@@ -42,8 +42,8 @@ export type UserTwapSliceFillsEvent = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode userTwapSliceFills} function. */
 export type UserTwapSliceFillsParameters = Omit<v.InferInput<typeof UserTwapSliceFillsRequest>, "type">;
@@ -54,7 +54,7 @@ export type UserTwapSliceFillsParameters = Omit<v.InferInput<typeof UserTwapSlic
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -80,12 +80,12 @@ export function userTwapSliceFills(
   config: SubscriptionConfig,
   params: UserTwapSliceFillsParameters,
   listener: (data: UserTwapSliceFillsEvent) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(UserTwapSliceFillsRequest, { type: "userTwapSliceFills", ...params });
   return config.transport.subscribe<UserTwapSliceFillsEvent>(payload.type, payload, (e) => {
     if (e.detail.user === payload.user) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/webData2.ts
+++ b/src/api/subscription/_methods/webData2.ts
@@ -32,8 +32,8 @@ export type WebData2Event = WebData2Response;
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode webData2} function. */
 export type WebData2Parameters = Omit<v.InferInput<typeof WebData2Request>, "type">;
@@ -46,7 +46,7 @@ export type WebData2Parameters = Omit<v.InferInput<typeof WebData2Request>, "typ
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -72,12 +72,12 @@ export function webData2(
   config: SubscriptionConfig,
   params: WebData2Parameters,
   listener: (data: WebData2Event) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(WebData2Request, { type: "webData2", ...params });
   return config.transport.subscribe<WebData2Event>(payload.type, payload, (e) => {
     if (e.detail.user === payload.user) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/_methods/webData3.ts
+++ b/src/api/subscription/_methods/webData3.ts
@@ -76,8 +76,8 @@ export type WebData3Event = {
 // ============================================================
 
 import { parse } from "../../../_base.ts";
-import type { ISubscription, TransportError } from "../../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_base/mod.ts";
+import type { ISubscription } from "../../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_base/mod.ts";
 
 /** Request parameters for the {@linkcode webData3} function. */
 export type WebData3Parameters = Omit<v.InferInput<typeof WebData3Request>, "type">;
@@ -88,7 +88,7 @@ export type WebData3Parameters = Omit<v.InferInput<typeof WebData3Request>, "typ
  * @param config General configuration for Subscription API subscriptions.
  * @param params Parameters specific to the API subscription.
  * @param listener A callback function to be called when the event is received.
- * @param onError An optional callback function to be called when the subscription fails.
+ * @param options Options to control the subscription lifecycle.
  * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
  *
  * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -114,12 +114,12 @@ export function webData3(
   config: SubscriptionConfig,
   params: WebData3Parameters,
   listener: (data: WebData3Event) => void,
-  onError?: (error: TransportError) => void,
+  options?: SubscriptionOptions,
 ): Promise<ISubscription> {
   const payload = parse(WebData3Request, { type: "webData3", ...params });
   return config.transport.subscribe<WebData3Event>(payload.type, payload, (e) => {
     if (e.detail.userState.user === payload.user) {
       listener(e.detail);
     }
-  }, { onError });
+  }, options);
 }

--- a/src/api/subscription/client.ts
+++ b/src/api/subscription/client.ts
@@ -3,8 +3,8 @@
  * @module
  */
 
-import type { ISubscription, TransportError } from "../../transport/mod.ts";
-import type { SubscriptionConfig } from "./_methods/_base/mod.ts";
+import type { ISubscription } from "../../transport/mod.ts";
+import type { SubscriptionConfig, SubscriptionOptions } from "./_methods/_base/mod.ts";
 
 // ============================================================
 // Methods Imports
@@ -107,7 +107,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -130,9 +130,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   activeAssetCtx(
     params: ActiveAssetCtxParameters,
     listener: (data: ActiveAssetCtxEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return activeAssetCtx(this.config_, params, listener, onError);
+    return activeAssetCtx(this.config_, params, listener, options);
   }
 
   /**
@@ -140,7 +140,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -163,9 +163,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   activeAssetData(
     params: ActiveAssetDataParameters,
     listener: (data: ActiveAssetDataEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return activeAssetData(this.config_, params, listener, onError);
+    return activeAssetData(this.config_, params, listener, options);
   }
 
   /**
@@ -173,7 +173,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -196,16 +196,16 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   activeSpotAssetCtx(
     params: ActiveSpotAssetCtxParameters,
     listener: (data: ActiveSpotAssetCtxEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return activeSpotAssetCtx(this.config_, params, listener, onError);
+    return activeSpotAssetCtx(this.config_, params, listener, options);
   }
 
   /**
    * Subscribe to asset contexts for all DEXs.
    *
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -227,9 +227,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    */
   allDexsAssetCtxs(
     listener: (data: AllDexsAssetCtxsEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return allDexsAssetCtxs(this.config_, listener, onError);
+    return allDexsAssetCtxs(this.config_, listener, options);
   }
 
   /**
@@ -237,7 +237,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -260,9 +260,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   allDexsClearinghouseState(
     params: AllDexsClearinghouseStateParameters,
     listener: (data: AllDexsClearinghouseStateEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return allDexsClearinghouseState(this.config_, params, listener, onError);
+    return allDexsClearinghouseState(this.config_, params, listener, options);
   }
 
   /**
@@ -270,7 +270,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -292,26 +292,23 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    */
   allMids(
     listener: (data: AllMidsEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription>;
   allMids(
     params: AllMidsParameters,
     listener: (data: AllMidsEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription>;
   allMids(
     paramsOrListener: AllMidsParameters | ((data: AllMidsEvent) => void),
-    listenerOrOnError?: ((data: AllMidsEvent) => void) | ((error: TransportError) => void),
-    maybeOnError?: (error: TransportError) => void,
+    listenerOrOptions?: ((data: AllMidsEvent) => void) | SubscriptionOptions,
+    maybeOptions?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    const params = typeof paramsOrListener === "function" ? {} : paramsOrListener;
-    const listener = (typeof paramsOrListener === "function" ? paramsOrListener : listenerOrOnError) as (
-      data: AllMidsEvent,
-    ) => void;
-    const onError = (typeof paramsOrListener === "function" ? listenerOrOnError : maybeOnError) as
-      | ((error: TransportError) => void)
-      | undefined;
-    return allMids(this.config_, params, listener, onError);
+    const isListenerFirst = typeof paramsOrListener === "function";
+    const params = isListenerFirst ? {} : paramsOrListener;
+    const listener = isListenerFirst ? paramsOrListener : listenerOrOptions as (data: AllMidsEvent) => void;
+    const options = isListenerFirst ? listenerOrOptions as SubscriptionOptions | undefined : maybeOptions;
+    return allMids(this.config_, params, listener, options);
   }
 
   /**
@@ -319,7 +316,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -341,26 +338,23 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    */
   assetCtxs(
     listener: (data: AssetCtxsEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription>;
   assetCtxs(
     params: AssetCtxsParameters,
     listener: (data: AssetCtxsEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription>;
   assetCtxs(
     paramsOrListener: AssetCtxsParameters | ((data: AssetCtxsEvent) => void),
-    listenerOrOnError?: ((data: AssetCtxsEvent) => void) | ((error: TransportError) => void),
-    maybeOnError?: (error: TransportError) => void,
+    listenerOrOptions?: ((data: AssetCtxsEvent) => void) | SubscriptionOptions,
+    maybeOptions?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    const params = typeof paramsOrListener === "function" ? {} : paramsOrListener;
-    const listener = (typeof paramsOrListener === "function" ? paramsOrListener : listenerOrOnError) as (
-      data: AssetCtxsEvent,
-    ) => void;
-    const onError = (typeof paramsOrListener === "function" ? listenerOrOnError : maybeOnError) as
-      | ((error: TransportError) => void)
-      | undefined;
-    return assetCtxs(this.config_, params, listener, onError);
+    const isListenerFirst = typeof paramsOrListener === "function";
+    const params = isListenerFirst ? {} : paramsOrListener;
+    const listener = isListenerFirst ? paramsOrListener : listenerOrOptions as (data: AssetCtxsEvent) => void;
+    const options = isListenerFirst ? listenerOrOptions as SubscriptionOptions | undefined : maybeOptions;
+    return assetCtxs(this.config_, params, listener, options);
   }
 
   /**
@@ -368,7 +362,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -391,9 +385,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   bbo(
     params: BboParameters,
     listener: (data: BboEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return bbo(this.config_, params, listener, onError);
+    return bbo(this.config_, params, listener, options);
   }
 
   /**
@@ -401,7 +395,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -424,9 +418,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   candle(
     params: CandleParameters,
     listener: (data: CandleEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return candle(this.config_, params, listener, onError);
+    return candle(this.config_, params, listener, options);
   }
 
   /**
@@ -434,7 +428,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -457,9 +451,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   clearinghouseState(
     params: ClearinghouseStateParameters,
     listener: (data: ClearinghouseStateEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return clearinghouseState(this.config_, params, listener, onError);
+    return clearinghouseState(this.config_, params, listener, options);
   }
 
   /**
@@ -469,7 +463,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    * which React Native does not provide; add a [polyfill](https://www.npmjs.com/package/compression-streams-polyfill) to use this subscription there.
    *
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -491,9 +485,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    */
   fastAssetCtxs(
     listener: (data: FastAssetCtxsEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return fastAssetCtxs(this.config_, listener, onError);
+    return fastAssetCtxs(this.config_, listener, options);
   }
 
   /**
@@ -501,7 +495,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -524,9 +518,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   l2Book(
     params: L2BookParameters,
     listener: (data: L2BookEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return l2Book(this.config_, params, listener, onError);
+    return l2Book(this.config_, params, listener, options);
   }
 
   /**
@@ -534,7 +528,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -557,9 +551,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   notification(
     params: NotificationParameters,
     listener: (data: NotificationEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return notification(this.config_, params, listener, onError);
+    return notification(this.config_, params, listener, options);
   }
 
   /**
@@ -567,7 +561,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -590,9 +584,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   openOrders(
     params: OpenOrdersParameters,
     listener: (data: OpenOrdersEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return openOrders(this.config_, params, listener, onError);
+    return openOrders(this.config_, params, listener, options);
   }
 
   /**
@@ -600,7 +594,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -623,16 +617,16 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   orderUpdates(
     params: OrderUpdatesParameters,
     listener: (data: OrderUpdatesEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return orderUpdates(this.config_, params, listener, onError);
+    return orderUpdates(this.config_, params, listener, options);
   }
 
   /**
    * Subscribe to prediction market outcome/question metadata updates.
    *
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -654,16 +648,16 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    */
   outcomeMetaUpdates(
     listener: (data: OutcomeMetaUpdatesEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return outcomeMetaUpdates(this.config_, listener, onError);
+    return outcomeMetaUpdates(this.config_, listener, options);
   }
 
   /**
    * Subscribe to context updates for all spot assets.
    *
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -685,9 +679,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    */
   spotAssetCtxs(
     listener: (data: SpotAssetCtxsEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return spotAssetCtxs(this.config_, listener, onError);
+    return spotAssetCtxs(this.config_, listener, options);
   }
 
   /**
@@ -695,7 +689,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -718,9 +712,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   spotState(
     params: SpotStateParameters,
     listener: (data: SpotStateEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return spotState(this.config_, params, listener, onError);
+    return spotState(this.config_, params, listener, options);
   }
 
   /**
@@ -728,7 +722,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -751,9 +745,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   trades(
     params: TradesParameters,
     listener: (data: TradesEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return trades(this.config_, params, listener, onError);
+    return trades(this.config_, params, listener, options);
   }
 
   /**
@@ -761,7 +755,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -784,9 +778,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   twapStates(
     params: TwapStatesParameters,
     listener: (data: TwapStatesEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return twapStates(this.config_, params, listener, onError);
+    return twapStates(this.config_, params, listener, options);
   }
 
   /**
@@ -794,7 +788,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -817,9 +811,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   userEvents(
     params: UserEventsParameters,
     listener: (data: UserEventsEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return userEvents(this.config_, params, listener, onError);
+    return userEvents(this.config_, params, listener, options);
   }
 
   /**
@@ -827,7 +821,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -850,9 +844,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   userFills(
     params: UserFillsParameters,
     listener: (data: UserFillsEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return userFills(this.config_, params, listener, onError);
+    return userFills(this.config_, params, listener, options);
   }
 
   /**
@@ -860,7 +854,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -883,9 +877,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   userFundings(
     params: UserFundingsParameters,
     listener: (data: UserFundingsEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return userFundings(this.config_, params, listener, onError);
+    return userFundings(this.config_, params, listener, options);
   }
 
   /**
@@ -893,7 +887,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -916,9 +910,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   userHistoricalOrders(
     params: UserHistoricalOrdersParameters,
     listener: (data: UserHistoricalOrdersEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return userHistoricalOrders(this.config_, params, listener, onError);
+    return userHistoricalOrders(this.config_, params, listener, options);
   }
 
   /**
@@ -926,7 +920,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -949,9 +943,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   userNonFundingLedgerUpdates(
     params: UserNonFundingLedgerUpdatesParameters,
     listener: (data: UserNonFundingLedgerUpdatesEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return userNonFundingLedgerUpdates(this.config_, params, listener, onError);
+    return userNonFundingLedgerUpdates(this.config_, params, listener, options);
   }
 
   /**
@@ -959,7 +953,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -982,9 +976,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   userTwapHistory(
     params: UserTwapHistoryParameters,
     listener: (data: UserTwapHistoryEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return userTwapHistory(this.config_, params, listener, onError);
+    return userTwapHistory(this.config_, params, listener, options);
   }
 
   /**
@@ -992,7 +986,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -1015,9 +1009,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   userTwapSliceFills(
     params: UserTwapSliceFillsParameters,
     listener: (data: UserTwapSliceFillsEvent) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return userTwapSliceFills(this.config_, params, listener, onError);
+    return userTwapSliceFills(this.config_, params, listener, options);
   }
 
   /**
@@ -1027,7 +1021,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -1050,9 +1044,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   webData2(
     params: WebData2Parameters,
     listener: (data: WebData2Event) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return webData2(this.config_, params, listener, onError);
+    return webData2(this.config_, params, listener, options);
   }
 
   /**
@@ -1060,7 +1054,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
    *
    * @param params Parameters specific to the API subscription.
    * @param listener A callback function to be called when the event is received.
-   * @param onError An optional callback function to be called when the subscription fails.
+   * @param options Options to control the subscription lifecycle.
    * @return A request-promise that resolves with a {@link ISubscription} object to manage the subscription lifecycle.
    *
    * @throws {ValidationError} When the request parameters fail validation (before sending).
@@ -1083,9 +1077,9 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
   webData3(
     params: WebData3Parameters,
     listener: (data: WebData3Event) => void,
-    onError?: (error: TransportError) => void,
+    options?: SubscriptionOptions,
   ): Promise<ISubscription> {
-    return webData3(this.config_, params, listener, onError);
+    return webData3(this.config_, params, listener, options);
   }
 }
 
@@ -1093,7 +1087,7 @@ export class SubscriptionClient<C extends SubscriptionConfig = SubscriptionConfi
 // Type Re-exports
 // ============================================================
 
-export type { SubscriptionConfig } from "./_methods/_base/mod.ts";
+export type { SubscriptionConfig, SubscriptionOptions } from "./_methods/_base/mod.ts";
 
 export type {
   ActiveAssetCtxEvent as ActiveAssetCtxWsEvent,

--- a/src/api/subscription/mod.ts
+++ b/src/api/subscription/mod.ts
@@ -23,7 +23,7 @@
  * @module
  */
 
-export type { SubscriptionConfig } from "./_methods/_base/mod.ts";
+export type { SubscriptionConfig, SubscriptionOptions } from "./_methods/_base/mod.ts";
 
 export * from "./_methods/activeAssetCtx.ts";
 export * from "./_methods/activeAssetData.ts";


### PR DESCRIPTION
**What & why**

Follow-up to #137, which reworked `WebSocketTransport.subscribe` to take an `options` object.
This brings every subscription method's last argument to the same shape — replacing the positional `onError?` callback with an `options` object that also carries a new `signal` to abort waiting for the confirmation.

**Type of change**

- [ ] Bug fix
- [x] New API method / feature
- [ ] Schema/type update to match the Hyperliquid API
- [x] Breaking change