### PR TITLE
refactor(api): align response types with the Hyperliquid API

### DIFF
--- a/src/api/info/_methods/meta.ts
+++ b/src/api/info/_methods/meta.ts
@@ -35,7 +35,11 @@ export type MetaResponse = {
     maxLeverage: number;
     /** Unique identifier for the margin requirements table. */
     marginTableId: number;
-    /** Indicates if only isolated margin trading is allowed. */
+    /**
+     * Indicates if only isolated margin trading is allowed.
+     *
+     * @deprecated use `marginMode` instead.
+     */
     onlyIsolated?: true;
     /** Indicates if the universe is delisted. */
     isDelisted?: true;

--- a/src/api/info/_methods/spotMeta.ts
+++ b/src/api/info/_methods/spotMeta.ts
@@ -24,7 +24,7 @@ export type SpotMetaResponse = {
   /** Trading universes available for spot trading. */
   universe: {
     /** Token indices included in this universe. */
-    tokens: number[];
+    tokens: [baseToken: number, quoteToken: number];
     /** Name of the universe. */
     name: string;
     /** Unique identifier of the universe. */

--- a/src/api/subscription/_methods/outcomeMetaUpdates.ts
+++ b/src/api/subscription/_methods/outcomeMetaUpdates.ts
@@ -63,6 +63,8 @@ export type OutcomeMetaUpdatesEvent = {
         fallbackOutcome: number;
         /** Array of named outcome identifiers. */
         namedOutcomes: number[];
+        /** Array of settled named outcome identifiers. */
+        settledNamedOutcomes: number[];
       };
     }
     | {

--- a/src/api/subscription/_methods/userEvents.ts
+++ b/src/api/subscription/_methods/userEvents.ts
@@ -35,6 +35,8 @@ export type UserEventsEvent =
   | {
     /** Funding update details. */
     funding: {
+      /** Timestamp of the funding event (in ms since epoch). */
+      time: number;
       /** Asset symbol (e.g., BTC). */
       coin: string;
       /**


### PR DESCRIPTION
- `outcomeMetaUpdates`: add `settledNamedOutcomes` to the `questionUpdated` event.
- `userEvents`: add `time` to the funding event.
- `spotMeta`: type `universe[].tokens` as a `[baseToken, quoteToken]` tuple.
- `meta`: deprecate `universe[].onlyIsolated` in favor of `marginMode`.

**Type of change**

- [ ] Bug fix
- [ ] New API method / feature
- [x] Schema/type update to match the Hyperliquid API
- [ ] Breaking change
