### PR TITLE
chore: bump version to 0.33.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nktkas/hyperliquid",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "license": "MIT",
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check --doc && deno task check:jsdoc && deno task check:export",


### PR DESCRIPTION
## What this does

Bumps `deno.json` `version` `0.32.2` → **`0.33.0`** (the single source of truth for both the JSR and npm publishes).

## Why minor, not patch

Per the SDK's own policy (`README.md` §Versioning): pre-`1.0.0`, **breaking changes bump the minor**, everything else bumps the patch — with the sole exception that breaks in the request/response/event types *mirroring the Hyperliquid API* ship as patch (the break comes from Hyperliquid, not the SDK).

There are 11 `!`-marked breaking commits since `v0.32.2`, and most break the **SDK's own surface** (outside that exception), so a minor is required:

- `refactor(signing)!` rework public API (#f5c8d91) + `feat(signing)!` add `canonicalize()` (#71049ef)
- `refactor(transport)!` rework the WebSocket transport (#137) + `refactor(transport/http)!` rework request pipeline & error handling
- `refactor(utils)!` rework price and size formatting (#144)
- `refactor(subscription)!` replace `onError` callback with an options object (#148) + replace `failureSignal` with `onError`
- `build!` require Node.js >=22.12.0 and migrate ESM-only — runtime-requirement break
- `refactor(api)!` extract the explorer API into a dedicated `ExplorerClient`
- `feat(api/exchange/noop)!` now takes a required nonce; `refactor(api/exchange/createVault)!` nonce handling

## Suggested release notes (for the `v0.33.0` GitHub Release)

> ## What's Changed
>
> **Breaking**
> - `refactor(signing)!`: rework public API and internal code; add `canonicalize()`
> - `refactor(transport)!`: rework the WebSocket transport (#137); rework HTTP request pipeline & error handling
> - `refactor(utils)!`: rework price and size formatting (#144)
> - `refactor(subscription)!`: replace `onError` callback with an options object (#148); replace `failureSignal` with `onError`
> - `build!`: require Node.js >=22.12.0 and migrate ESM-only
> - `refactor(api)!`: extract the explorer API into a dedicated `ExplorerClient`
> - `feat(api/exchange/noop)!`: now takes a required nonce; `refactor(api/exchange/createVault)!`: match inner action nonce to envelope nonce
>
> **Features**
> - `feat(exchange)`: add `disableDex` to perpDeploy (#150); add `disableQuoteToken`, remove `enableAlignedQuoteToken` from spotDeploy (#149); optional `fast` flag on cancel / cancelByCloid (#146); `always_place` (a) on modify / batchModify (#145)
> - `feat(subscription)`: add `fastAssetCtxs` (#147); optional `fast` field on l2Book (#142)
> - `feat(api)`: `settledOutcome`, `authorizeAqav2Role`, `outcomeMeta.quoteToken` (#135), hip4 outcome-market support (#132), `getSymbolBySpotPairId` (#126)
>
> **Fixes / deps**
> - `fix(mod)`: expose `AbstractWalletError` from the main import
> - `build(deps)`: bump @valibot/valibot, @nktkas/rews, @std/msgpack, @noble/hashes
>
> **Full Changelog**: https://github.com/nktkas/hyperliquid/compare/v0.32.2...v0.33.0

After merge, the release path is unchanged: cut a `v0.33.0` GitHub Release → `publish_jsr.yml` + `publish_npm.yml` fire on `release: published` and publish via OIDC (npm dist-tag `latest`, since the version has no prerelease suffix).
