### PR TITLE
test(api): fix the online test suite

### DIFF
--- a/tests/api/exchange/_t.ts
+++ b/tests/api/exchange/_t.ts
@@ -177,7 +177,7 @@ export async function openOrder(
   midPx: string;
 }> {
   // Top-up account
-  await topUpPerp(client, "13");
+  await topUpPerp(client, "20");
 
   // Get market data
   const id = symbolConverter.getAssetId(symbol)!;
@@ -187,7 +187,7 @@ export async function openOrder(
   // Calculate order parameters
   const pxDown = formatPrice(Number(midPx) * (1 - slippage), szDecimals);
   const pxUp = formatPrice(Number(midPx) * (1 + slippage), szDecimals);
-  const sz = formatSize(11 / Number(midPx), szDecimals);
+  const sz = formatSize(15 / Number(midPx), szDecimals);
 
   let executionPx: string;
   if (type === "market") {

--- a/tests/api/info/subAccounts.test.ts
+++ b/tests/api/info/subAccounts.test.ts
@@ -25,6 +25,14 @@ runTest({
       "#/anyOf/0/items/properties/clearinghouseState/properties/assetPositions/items/properties/position/properties/liquidationPx/defined",
       "#/anyOf/0/items/properties/spotState/properties/evmEscrows/present",
       "#/anyOf/0/items/properties/spotState/properties/balances/items/anyOf/1",
+      "#/anyOf/0/items/properties/spotState/properties/portfolioMarginEnabled/present",
+      "#/anyOf/0/items/properties/spotState/properties/portfolioMarginRatio/present",
+      "#/anyOf/0/items/properties/spotState/properties/tokenToPortfolioBorrowRatio/present",
+      "#/anyOf/0/items/properties/spotState/properties/tokenToAvailableAfterMaintenance/present",
+      "#/anyOf/0/items/properties/spotState/properties/balances/items/anyOf/0/properties/spotHold/present",
+      "#/anyOf/0/items/properties/spotState/properties/balances/items/anyOf/0/properties/ltv/present",
+      "#/anyOf/0/items/properties/spotState/properties/balances/items/anyOf/0/properties/borrowed/present",
+      "#/anyOf/0/items/properties/spotState/properties/balances/items/anyOf/0/properties/supplied/present",
     ]);
   },
 });

--- a/tests/api/info/subAccounts2.test.ts
+++ b/tests/api/info/subAccounts2.test.ts
@@ -25,6 +25,14 @@ runTest({
       "#/anyOf/0/items/properties/dexToClearinghouseState/items/items/1/properties/assetPositions/items/properties/position/properties/liquidationPx/defined",
       "#/anyOf/0/items/properties/spotState/properties/evmEscrows/present",
       "#/anyOf/0/items/properties/spotState/properties/balances/items/anyOf/1",
+      "#/anyOf/0/items/properties/spotState/properties/portfolioMarginEnabled/present",
+      "#/anyOf/0/items/properties/spotState/properties/portfolioMarginRatio/present",
+      "#/anyOf/0/items/properties/spotState/properties/tokenToPortfolioBorrowRatio/present",
+      "#/anyOf/0/items/properties/spotState/properties/tokenToAvailableAfterMaintenance/present",
+      "#/anyOf/0/items/properties/spotState/properties/balances/items/anyOf/0/properties/spotHold/present",
+      "#/anyOf/0/items/properties/spotState/properties/balances/items/anyOf/0/properties/ltv/present",
+      "#/anyOf/0/items/properties/spotState/properties/balances/items/anyOf/0/properties/borrowed/present",
+      "#/anyOf/0/items/properties/spotState/properties/balances/items/anyOf/0/properties/supplied/present",
     ]);
   },
 });

--- a/tests/api/info/webData2.test.ts
+++ b/tests/api/info/webData2.test.ts
@@ -39,6 +39,14 @@ runTest({
       "#/properties/agentAddress/defined",
       "#/properties/agentValidUntil/defined",
       "#/properties/openOrders/items/properties/children/*",
+      "#/properties/spotState/properties/portfolioMarginEnabled/present",
+      "#/properties/spotState/properties/portfolioMarginRatio/present",
+      "#/properties/spotState/properties/tokenToPortfolioBorrowRatio/present",
+      "#/properties/spotState/properties/tokenToAvailableAfterMaintenance/present",
+      "#/properties/spotState/properties/balances/items/anyOf/0/properties/spotHold/present",
+      "#/properties/spotState/properties/balances/items/anyOf/0/properties/ltv/present",
+      "#/properties/spotState/properties/balances/items/anyOf/0/properties/borrowed/present",
+      "#/properties/spotState/properties/balances/items/anyOf/0/properties/supplied/present",
     ]);
   },
 });

--- a/tests/api/subscription/spotState.test.ts
+++ b/tests/api/subscription/spotState.test.ts
@@ -25,6 +25,15 @@ runTest({
     }, 10_000);
 
     schemaCoverage(paramsSchema, params);
-    schemaCoverage(responseSchema, data);
+    schemaCoverage(responseSchema, data, [
+      "#/properties/spotState/properties/portfolioMarginEnabled/present",
+      "#/properties/spotState/properties/portfolioMarginRatio/present",
+      "#/properties/spotState/properties/tokenToPortfolioBorrowRatio/present",
+      "#/properties/spotState/properties/tokenToAvailableAfterMaintenance/present",
+      "#/properties/spotState/properties/balances/items/anyOf/0/properties/spotHold/present",
+      "#/properties/spotState/properties/balances/items/anyOf/0/properties/ltv/present",
+      "#/properties/spotState/properties/balances/items/anyOf/0/properties/borrowed/present",
+      "#/properties/spotState/properties/balances/items/anyOf/0/properties/supplied/present",
+    ]);
   },
 });

--- a/tests/api/subscription/userHistoricalOrders.test.ts
+++ b/tests/api/subscription/userHistoricalOrders.test.ts
@@ -29,7 +29,9 @@ runTest({
     schemaCoverage(paramsSchema, params);
     schemaCoverage(responseSchema, data, [
       "#/properties/orderHistory/items/properties/order/properties/orderType/enum/3",
+      "#/properties/orderHistory/items/properties/order/properties/tif/enum/1",
       "#/properties/orderHistory/items/properties/order/properties/tif/enum/5",
+      "#/properties/orderHistory/items/properties/order/properties/children/*",
       "#/properties/orderHistory/items/properties/status/enum/4",
       "#/properties/orderHistory/items/properties/status/enum/5",
       "#/properties/orderHistory/items/properties/status/enum/6",

--- a/tests/api/subscription/webData2.test.ts
+++ b/tests/api/subscription/webData2.test.ts
@@ -41,6 +41,15 @@ runTest({
       "#/properties/perpsAtOpenInterestCap/present",
       "#/properties/agentAddress/defined",
       "#/properties/agentValidUntil/defined",
+      "#/properties/openOrders/items/properties/children/*",
+      "#/properties/spotState/properties/portfolioMarginEnabled/present",
+      "#/properties/spotState/properties/portfolioMarginRatio/present",
+      "#/properties/spotState/properties/tokenToPortfolioBorrowRatio/present",
+      "#/properties/spotState/properties/tokenToAvailableAfterMaintenance/present",
+      "#/properties/spotState/properties/balances/items/anyOf/0/properties/spotHold/present",
+      "#/properties/spotState/properties/balances/items/anyOf/0/properties/ltv/present",
+      "#/properties/spotState/properties/balances/items/anyOf/0/properties/borrowed/present",
+      "#/properties/spotState/properties/balances/items/anyOf/0/properties/supplied/present",
     ]);
   },
 });


### PR DESCRIPTION
**What & why**

- `exchange/_t.ts`: raise the `openOrder` notional above the $10 minimum.
- `subAccounts`, `subAccounts2`, `webData2`, `spotState`: ignore the testnet-absent portfolio-margin / borrow-lend `spotState` fields.
- `userHistoricalOrders`, `webData2`: ignore the order `children` subtree.

**Type of change**

- [ ] Bug fix
- [ ] New API method / feature
- [ ] Schema/type update to match the Hyperliquid API
- [ ] Breaking change
