### PR TITLE
refactor(api): align request schemas with the Hyperliquid API

### DIFF
--- a/src/api/exchange/_methods/perpDeploy.ts
+++ b/src/api/exchange/_methods/perpDeploy.ts
@@ -131,6 +131,35 @@ export const PerpDeployRequest = /* @__PURE__ */ (() => {
       v.object({
         /** Type of action. */
         type: v.literal("perpDeploy"),
+        /** Parameters for inserting a margin table into a dex. */
+        insertMarginTable: v.object({
+          /** DEX name. */
+          dex: v.string(),
+          /** Margin table to insert. */
+          marginTable: v.object({
+            /** Description of the margin table. */
+            description: v.string(),
+            /**
+             * Margin tiers, sorted by increasing lower bound and decreasing max leverage.
+             * A maximum of 3 tiers is allowed.
+             */
+            marginTiers: v.pipe(
+              v.array(
+                v.object({
+                  /** Position notional value above which leverage is constrained by `maxLeverage`. */
+                  lowerBound: UnsignedInteger,
+                  /** Maximum leverage (between `1` and `50`). */
+                  maxLeverage: v.pipe(UnsignedInteger, v.minValue(1), v.maxValue(50)),
+                }),
+              ),
+              v.maxLength(3),
+            ),
+          }),
+        }),
+      }),
+      v.object({
+        /** Type of action. */
+        type: v.literal("perpDeploy"),
         /** Parameters for setting the fee recipient. */
         setFeeRecipient: v.object({
           /** DEX name. */

--- a/src/api/exchange/_methods/usdClassTransfer.ts
+++ b/src/api/exchange/_methods/usdClassTransfer.ts
@@ -20,8 +20,19 @@ export const UsdClassTransferRequest = /* @__PURE__ */ (() => {
       signatureChainId: Hex,
       /** Hyperliquid network type. */
       hyperliquidChain: v.picklist(["Mainnet", "Testnet"]),
-      /** Amount to transfer (1 = $1). */
-      amount: UnsignedDecimal,
+      /**
+       * Amount to transfer (1 = $1).
+       *
+       * To transfer on behalf of a subaccount, suffix the amount with ` subaccount:<address>`,
+       * e.g. `"1 subaccount:0x0000000000000000000000000000000000000000"`.
+       */
+      amount: v.union([
+        UnsignedDecimal,
+        v.pipe(
+          v.string(),
+          v.regex(/^[0-9]+(\.[0-9]+)?\s+subaccount:0x[0-9a-fA-F]{40}$/),
+        ),
+      ]),
       /** `true` for spot to perp, `false` for perp to spot. */
       toPerp: v.boolean(),
       /** Nonce (timestamp in ms) used to prevent replay attacks. */

--- a/src/api/info/_methods/spotClearinghouseState.ts
+++ b/src/api/info/_methods/spotClearinghouseState.ts
@@ -16,8 +16,6 @@ export const SpotClearinghouseStateRequest = /* @__PURE__ */ (() => {
     type: v.literal("spotClearinghouseState"),
     /** User address. */
     user: Address,
-    /** DEX name (empty string for main dex). */
-    dex: v.optional(v.string()),
   });
 })();
 export type SpotClearinghouseStateRequest = v.InferOutput<typeof SpotClearinghouseStateRequest>;

--- a/src/api/info/_methods/userTwapSliceFillsByTime.ts
+++ b/src/api/info/_methods/userTwapSliceFillsByTime.ts
@@ -21,8 +21,6 @@ export const UserTwapSliceFillsByTimeRequest = /* @__PURE__ */ (() => {
     startTime: UnsignedInteger,
     /** End time (in ms since epoch). */
     endTime: v.nullish(UnsignedInteger),
-    /** If true, partial fills are aggregated when a crossing order fills multiple resting orders. */
-    aggregateByTime: v.optional(v.boolean()),
   });
 })();
 export type UserTwapSliceFillsByTimeRequest = v.InferOutput<typeof UserTwapSliceFillsByTimeRequest>;

--- a/tests/api/exchange/perpDeploy.test.ts
+++ b/tests/api/exchange/perpDeploy.test.ts
@@ -143,6 +143,18 @@ runTest({
       { haltTrading: { coin: "TEST0", isHalted: true } },
       { setMarginTableIds: [["TEST0", 1]] },
       {
+        insertMarginTable: {
+          dex: "test",
+          marginTable: {
+            description: "test",
+            marginTiers: [
+              { lowerBound: 0, maxLeverage: 50 },
+              { lowerBound: 1000000, maxLeverage: 10 },
+            ],
+          },
+        },
+      },
+      {
         setFeeRecipient: {
           dex: "test",
           feeRecipient: "0x0000000000000000000000000000000000000000",

--- a/tests/api/info/spotClearinghouseState.test.ts
+++ b/tests/api/info/spotClearinghouseState.test.ts
@@ -15,7 +15,6 @@ runTest({
     const params: SpotClearinghouseStateParameters[] = [
       { user: "0x563C175E6f11582f65D6d9E360A618699DEe14a9" }, // balances.length > 0
       { user: "0x1defed46db35334232b9f5fd2e5c6180276fb99d" }, // evmEscrows.length > 0
-      { user: "0x563C175E6f11582f65D6d9E360A618699DEe14a9", dex: "gato" },
     ];
 
     const data = await Promise.all(params.map((p) => client.spotClearinghouseState(p)));

--- a/tests/api/info/userTwapSliceFillsByTime.test.ts
+++ b/tests/api/info/userTwapSliceFillsByTime.test.ts
@@ -15,11 +15,9 @@ runTest({
     const now = Date.now();
     const fiveYears = 1000 * 60 * 60 * 24 * 365 * 5;
     const params: UserTwapSliceFillsByTimeParameters[] = [
-      { user: "0x563C175E6f11582f65D6d9E360A618699DEe14a9", startTime: now - fiveYears }, // endTime absent, aggregateByTime absent
+      { user: "0x563C175E6f11582f65D6d9E360A618699DEe14a9", startTime: now - fiveYears }, // endTime absent
       { user: "0x563C175E6f11582f65D6d9E360A618699DEe14a9", startTime: now - fiveYears, endTime: now }, // endTime present
       { user: "0x563C175E6f11582f65D6d9E360A618699DEe14a9", startTime: now - fiveYears, endTime: null }, // endTime null
-      { user: "0x563C175E6f11582f65D6d9E360A618699DEe14a9", startTime: now - fiveYears, aggregateByTime: true }, // aggregateByTime true
-      { user: "0x563C175E6f11582f65D6d9E360A618699DEe14a9", startTime: now - fiveYears, aggregateByTime: false }, // aggregateByTime false
     ];
 
     const data = await Promise.all(params.map((p) => client.userTwapSliceFillsByTime(p)));


### PR DESCRIPTION
**What & why**

- `perpDeploy`: add the `insertMarginTable` action.
- `usdClassTransfer`: support the `subaccount:<address>` suffix on `amount`.
- `spotClearinghouseState`: remove the `dex` field.
- `userTwapSliceFillsByTime`: remove the `aggregateByTime` field.

**Type of change**

- [ ] Bug fix
- [ ] New API method / feature
- [x] Schema/type update to match the Hyperliquid API
- [ ] Breaking change
